### PR TITLE
make EventProps more usable

### DIFF
--- a/js/src/main/scala/com/raquo/domtypes/jsdom/defs/package.scala
+++ b/js/src/main/scala/com/raquo/domtypes/jsdom/defs/package.scala
@@ -6,13 +6,14 @@ import org.scalajs.dom
 package object defs {
 
   object eventProps {
-    type ClipboardEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.ClipboardEventProps[EP, dom.Event]
+    type ClipboardEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.ClipboardEventProps[EP, dom.Event, dom.ClipboardEvent]
     type ErrorEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.ErrorEventProps[EP, dom.Event, dom.ErrorEvent]
-    type FormEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.FormEventProps[EP, dom.Event]
+    type FormEventProps[EP[_ <: dom.Event]] = FormEventPropsWithValue[EP, dom.Event]
+    type FormEventPropsWithValue[EP[_ <: dom.Event], DomValueElementEvent <: dom.Event] = generic.defs.eventProps.FormEventProps[EP, dom.Event, dom.FocusEvent, DomValueElementEvent]
     type KeyboardEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.KeyboardEventProps[EP, dom.Event, dom.KeyboardEvent]
     type MediaEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.MediaEventProps[EP, dom.Event]
     type MiscellaneousEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.MiscellaneousEventProps[EP, dom.Event]
-    type MouseEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.MouseEventProps[EP, dom.Event, dom.MouseEvent]
+    type MouseEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.MouseEventProps[EP, dom.Event, dom.MouseEvent, dom.DragEvent]
     type WindowEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.WindowEventProps[EP, dom.Event]
   }
 

--- a/js/src/main/scala/com/raquo/domtypes/jsdom/defs/package.scala
+++ b/js/src/main/scala/com/raquo/domtypes/jsdom/defs/package.scala
@@ -2,14 +2,25 @@ package com.raquo.domtypes.jsdom
 
 import com.raquo.domtypes.generic
 import org.scalajs.dom
+import org.scalajs.dom.html
+import scala.scalajs.js.annotation.ScalaJSDefined
 
 package object defs {
+
+  @ScalaJSDefined
+  class ValueElementEvent extends dom.Event {
+    def targetValue: String = target match {
+      case input: html.Input => input.value
+      case textarea: html.TextArea => textarea.value
+      case select: html.Select => select.value
+      case elem: html.Element => elem.textContent // for contenteditable elements
+    }
+  }
 
   object eventProps {
     type ClipboardEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.ClipboardEventProps[EP, dom.Event, dom.ClipboardEvent]
     type ErrorEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.ErrorEventProps[EP, dom.Event, dom.ErrorEvent]
-    type FormEventProps[EP[_ <: dom.Event]] = FormEventPropsWithValue[EP, dom.Event]
-    type FormEventPropsWithValue[EP[_ <: dom.Event], DomValueElementEvent <: dom.Event] = generic.defs.eventProps.FormEventProps[EP, dom.Event, dom.FocusEvent, DomValueElementEvent]
+    type FormEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.FormEventProps[EP, dom.Event, dom.FocusEvent, ValueElementEvent]
     type KeyboardEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.KeyboardEventProps[EP, dom.Event, dom.KeyboardEvent]
     type MediaEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.MediaEventProps[EP, dom.Event]
     type MiscellaneousEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.MiscellaneousEventProps[EP, dom.Event]

--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/eventProps/ClipboardEventProps.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/eventProps/ClipboardEventProps.scala
@@ -7,20 +7,20 @@ import com.raquo.domtypes.generic.builders.EventPropBuilder
   *
   * For type param docs see [[EventPropBuilder]]
   */
-trait ClipboardEventProps[EP[_ <: DomEvent], DomEvent] { this: EventPropBuilder[EP, DomEvent] =>
+trait ClipboardEventProps[EP[_ <: DomEvent], DomEvent, DomClipboardEvent <: DomEvent] { this: EventPropBuilder[EP, DomEvent] =>
 
   /**
     * Fires when the user copies the content of an element
     */
-  lazy val onCopy: EP[DomEvent] = eventProp("copy")
+  lazy val onCopy: EP[DomClipboardEvent] = eventProp("copy")
 
   /**
     * Fires when the user cuts the content of an element
     */
-  lazy val onCut: EP[DomEvent] = eventProp("cut")
+  lazy val onCut: EP[DomClipboardEvent] = eventProp("cut")
 
   /**
     * Fires when the user pastes some content in an element
     */
-  lazy val onPaste: EP[DomEvent] = eventProp("paste")
+  lazy val onPaste: EP[DomClipboardEvent] = eventProp("paste")
 }

--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/eventProps/FormEventProps.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/eventProps/FormEventProps.scala
@@ -2,14 +2,7 @@ package com.raquo.domtypes.generic.defs.eventProps
 
 import com.raquo.domtypes.generic.builders.EventPropBuilder
 
-trait FormEventProps[EP[_ <: DomEvent], DomEvent] { this: EventPropBuilder[EP, DomEvent] =>
-
-  /**
-    * The blur event is raised when an element loses focus.
-    *
-    * MDN
-    */
-  lazy val onBlur: EP[DomEvent] = eventProp("blur")
+trait FormEventProps[EP[_ <: DomEvent], DomEvent, DomFocusEvent <: DomEvent, DomValueElementEvent <: DomEvent] { this: EventPropBuilder[EP, DomEvent] =>
 
   /**
     * The change event is fired for input, select, and textarea elements
@@ -17,14 +10,7 @@ trait FormEventProps[EP[_ <: DomEvent], DomEvent] { this: EventPropBuilder[EP, D
     *
     * MDN
     */
-  lazy val onChange: EP[DomEvent] = eventProp("change")
-
-  /**
-    * The focus event is raised when the user sets focus on the given element.
-    *
-    * MDN
-    */
-  lazy val onFocus: EP[DomEvent] = eventProp("focus")
+  lazy val onChange: EP[DomValueElementEvent] = eventProp("change")
 
   /**
     * The select event only fires when text inside a text input or textarea is
@@ -32,7 +18,28 @@ trait FormEventProps[EP[_ <: DomEvent], DomEvent] { this: EventPropBuilder[EP, D
     *
     * MDN
     */
-  lazy val onSelect: EP[DomEvent] = eventProp("select")
+  lazy val onSelect: EP[DomValueElementEvent] = eventProp("select")
+
+  /**
+    * The input event is fired for input, select, textarea, and
+    * contenteditable elements when it gets user input.
+    */
+  lazy val onInput: EP[DomValueElementEvent] = eventProp("input")
+
+  /**
+    * The blur event is raised when an element loses focus.
+    *
+    * MDN
+    */
+  lazy val onBlur: EP[DomFocusEvent] = eventProp("blur")
+
+
+  /**
+    * The focus event is raised when the user sets focus on the given element.
+    *
+    * MDN
+    */
+  lazy val onFocus: EP[DomFocusEvent] = eventProp("focus")
 
   /**
     * The submit event is raised when the user clicks a submit button in a form
@@ -48,16 +55,6 @@ trait FormEventProps[EP[_ <: DomEvent], DomEvent] { this: EventPropBuilder[EP, D
     * MDN
     */
   lazy val onReset: EP[DomEvent] = eventProp("reset")
-
-  /**
-    * Script to be run when a context menu is triggered
-    */
-  lazy val onContextMenu: EP[DomEvent] = eventProp("contextmenu")
-
-  /**
-    * Script to be run when an element gets user input
-    */
-  lazy val onInput: EP[DomEvent] = eventProp("input")
 
   /**
     * Script to be run when an element is invalid

--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/eventProps/MouseEventProps.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/eventProps/MouseEventProps.scala
@@ -5,7 +5,7 @@ import com.raquo.domtypes.generic.builders.EventPropBuilder
 /**
   * Mouse Events: triggered by a mouse, or similar user actions.
   */
-trait MouseEventProps[EP[_ <: DomEvent], DomEvent, DomMouseEvent <: DomEvent] { this: EventPropBuilder[EP, DomEvent] =>
+trait MouseEventProps[EP[_ <: DomEvent], DomEvent, DomMouseEvent <: DomEvent, DomDragEvent <: DomEvent] { this: EventPropBuilder[EP, DomEvent] =>
 
   /**
     * The click event is raised when the user clicks on an element. The click
@@ -22,41 +22,6 @@ trait MouseEventProps[EP[_ <: DomEvent], DomEvent, DomMouseEvent <: DomEvent] { 
     * MDN
     */
   lazy val onDblClick: EP[DomMouseEvent] = eventProp("dblclick")
-
-  /**
-    * Script to be run when an element is dragged
-    */
-  val onDrag: EP[DomMouseEvent] = eventProp("drag")
-
-  /**
-    * Script to be run at the end of a drag operation
-    */
-  lazy val onDragEnd: EP[DomMouseEvent] = eventProp("dragend")
-
-  /**
-    * Script to be run when an element has been dragged to a valid drop target
-    */
-  lazy val onDragEnter: EP[DomMouseEvent] = eventProp("dragenter")
-
-  /**
-    * Script to be run when an element leaves a valid drop target
-    */
-  lazy val onDragLeave: EP[DomMouseEvent] = eventProp("dragleave")
-
-  /**
-    * Script to be run when an element is being dragged over a valid drop target
-    */
-  lazy val onDragOver: EP[DomMouseEvent] = eventProp("dragover")
-
-  /**
-    * Script to be run at the start of a drag operation
-    */
-  lazy val onDragStart: EP[DomMouseEvent] = eventProp("dragstart")
-
-  /**
-    * Script to be run when dragged element is being dropped
-    */
-  lazy val onDrop: EP[DomMouseEvent] = eventProp("drop")
 
   /**
     * The mousedown event is raised when the user presses the mouse button.
@@ -107,4 +72,44 @@ trait MouseEventProps[EP[_ <: DomEvent], DomEvent, DomMouseEvent <: DomEvent] { 
     * Fires when the mouse wheel rolls up or down over an element
     */
   lazy val onWheel: EP[DomMouseEvent] = eventProp("wheel")
+
+  /**
+    * Script to be run when a context menu is triggered
+    */
+  lazy val onContextMenu: EP[DomMouseEvent] = eventProp("contextmenu")
+
+  /**
+    * Script to be run when an element is dragged
+    */
+  lazy val onDrag: EP[DomDragEvent] = eventProp("drag")
+
+  /**
+    * Script to be run at the end of a drag operation
+    */
+  lazy val onDragEnd: EP[DomDragEvent] = eventProp("dragend")
+
+  /**
+    * Script to be run when an element has been dragged to a valid drop target
+    */
+  lazy val onDragEnter: EP[DomDragEvent] = eventProp("dragenter")
+
+  /**
+    * Script to be run when an element leaves a valid drop target
+    */
+  lazy val onDragLeave: EP[DomDragEvent] = eventProp("dragleave")
+
+  /**
+    * Script to be run when an element is being dragged over a valid drop target
+    */
+  lazy val onDragOver: EP[DomDragEvent] = eventProp("dragover")
+
+  /**
+    * Script to be run at the start of a drag operation
+    */
+  lazy val onDragStart: EP[DomDragEvent] = eventProp("dragstart")
+
+  /**
+    * Script to be run when dragged element is being dropped
+    */
+  lazy val onDrop: EP[DomDragEvent] = eventProp("drop")
 }


### PR DESCRIPTION
This was needed for integrating with outwatch, as we rely on the types of some events that were missing. For `FormEventProps`, I have invented a type parameter `ValueChangeEvent` for events that trigger on value changes in input/textarea/contenteditable (`onInput`, `onChange`, `onSelect`).

This is not complete, as I think, some more events could use more specific typing. But those were the ones we needed so far :)