### PR TITLE
handle events with dom.Element target and access to string value

### DIFF
--- a/js/src/main/scala/com/raquo/domtypes/jsdom/defs/package.scala
+++ b/js/src/main/scala/com/raquo/domtypes/jsdom/defs/package.scala
@@ -7,18 +7,28 @@ import scala.scalajs.js
 
 package object defs {
 
-  /** Type refinement for events that are fired on input elements.
-    * You can safely use this type for `onChange` and `onSelect` events,
-    * and SOME `onInput` events. See README for more details. */
   @js.native
-  trait InputElementTargetEvent extends dom.Event {
-    override def target: dom.html.Input = js.native
+  //TODO: maybe even ElementTargetEvent[T <: dom.html.Element]?
+  trait ElementTargetEvent extends dom.Event {
+    override def target: dom.html.Element = js.native
+  }
+
+  implicit class ElementTargetEventWithValue(val ev: ElementTargetEvent) extends AnyVal {
+    import dom.html
+
+    def targetValue: String = ev.target match {
+      case input: html.Input => input.value
+      case textarea: html.TextArea => textarea.value
+      case select: html.Select => select.value
+      case elem => elem.textContent // for contenteditable
+    }
   }
 
   object eventProps {
     type ClipboardEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.ClipboardEventProps[EP, dom.Event, dom.ClipboardEvent]
     type ErrorEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.ErrorEventProps[EP, dom.Event, dom.ErrorEvent]
-    type FormEventProps[EP[_ <: dom.Event], DomInputEvent <: dom.Event] = generic.defs.eventProps.FormEventProps[EP, dom.Event, dom.FocusEvent, InputElementTargetEvent, DomInputEvent]
+    type FormEventProps[EP[_ <: dom.Event]] = FormEventPropsWithInputEvent[EP, dom.Event]
+    type FormEventPropsWithInputEvent[EP[_ <: dom.Event], DomInputEvent <: dom.Event] = generic.defs.eventProps.FormEventProps[EP, dom.Event, dom.FocusEvent, DomInputEvent, ElementTargetEvent]
     type KeyboardEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.KeyboardEventProps[EP, dom.Event, dom.KeyboardEvent]
     type MediaEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.MediaEventProps[EP, dom.Event]
     type MiscellaneousEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.MiscellaneousEventProps[EP, dom.Event]

--- a/js/src/test/scala/com/raquo/domtypes/CompileTest.scala
+++ b/js/src/test/scala/com/raquo/domtypes/CompileTest.scala
@@ -8,7 +8,6 @@ import com.raquo.domtypes.generic.defs.props.Props
 import com.raquo.domtypes.generic.defs.reflectedAttrs.ReflectedAttrs
 import com.raquo.domtypes.generic.defs.styles.{Styles, Styles2}
 import com.raquo.domtypes.generic.keys.{Attr, EventProp, Prop, Style}
-import com.raquo.domtypes.jsdom.defs.InputElementTargetEvent
 import com.raquo.domtypes.jsdom.defs.eventProps.{ClipboardEventProps, ErrorEventProps, FormEventProps, KeyboardEventProps, MediaEventProps, MiscellaneousEventProps, MouseEventProps, WindowEventProps}
 import com.raquo.domtypes.jsdom.defs.tags.{DocumentTags, EmbedTags, FormTags, GroupingTags, MiscTags, SectionTags, TableTags, TextTags}
 import org.scalajs.dom
@@ -39,7 +38,7 @@ class CompileTest {
     // Event Props
     with ClipboardEventProps[EventProp]
     with ErrorEventProps[EventProp]
-    with FormEventProps[EventProp, InputElementTargetEvent] // Note: InputElementTargetEvent is not a 100% type safe choice. See README.
+    with FormEventProps[EventProp]
     with KeyboardEventProps[EventProp]
     with MediaEventProps[EventProp]
     with MiscellaneousEventProps[EventProp]

--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/eventProps/FormEventProps.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/eventProps/FormEventProps.scala
@@ -12,7 +12,7 @@ import com.raquo.domtypes.generic.builders.EventPropBuilder
   *            DOM InputEvent https://developer.mozilla.org/en-US/docs/Web/API/InputEvent
   *            Note: This type is not implemented in scala-js-dom
   */
-trait FormEventProps[EP[_ <: DomEvent], DomEvent, DomFocusEvent <: DomEvent, DomInputElementTargetEvent <: DomEvent, DomInputEvent <: DomEvent] { this: EventPropBuilder[EP, DomEvent] =>
+trait FormEventProps[EP[_ <: DomEvent], DomEvent, DomFocusEvent <: DomEvent, DomInputEvent <: DomEvent, DomElementTargetEvent <: DomEvent] { this: EventPropBuilder[EP, DomEvent] =>
 
   /**
     * The change event is fired for input, select, and textarea elements
@@ -20,7 +20,7 @@ trait FormEventProps[EP[_ <: DomEvent], DomEvent, DomFocusEvent <: DomEvent, Dom
     *
     * MDN
     */
-  lazy val onChange: EP[DomInputElementTargetEvent] = eventProp("change")
+  lazy val onChange: EP[DomEvent with DomElementTargetEvent] = eventProp("change")
 
   /**
     * The select event only fires when text inside a text input or textarea is
@@ -28,20 +28,20 @@ trait FormEventProps[EP[_ <: DomEvent], DomEvent, DomFocusEvent <: DomEvent, Dom
     *
     * MDN
     */
-  lazy val onSelect: EP[DomInputElementTargetEvent] = eventProp("select")
+  lazy val onSelect: EP[DomEvent with DomElementTargetEvent] = eventProp("select")
 
   /**
     * The input event is fired for input, select, textarea, and
     * contentEditable elements when it gets user input.
     */
-  lazy val onInput: EP[DomInputEvent] = eventProp("input")
+  lazy val onInput: EP[DomInputEvent with DomElementTargetEvent] = eventProp("input")
 
   /**
     * The blur event is raised when an element loses focus.
     *
     * MDN
     */
-  lazy val onBlur: EP[DomFocusEvent] = eventProp("blur")
+  lazy val onBlur: EP[DomFocusEvent with DomElementTargetEvent] = eventProp("blur")
 
 
   /**
@@ -49,7 +49,7 @@ trait FormEventProps[EP[_ <: DomEvent], DomEvent, DomFocusEvent <: DomEvent, Dom
     *
     * MDN
     */
-  lazy val onFocus: EP[DomFocusEvent] = eventProp("focus")
+  lazy val onFocus: EP[DomFocusEvent with DomElementTargetEvent] = eventProp("focus")
 
   /**
     * The submit event is fired when the user clicks a submit button in a form
@@ -57,22 +57,22 @@ trait FormEventProps[EP[_ <: DomEvent], DomEvent, DomFocusEvent <: DomEvent, Dom
     *
     * MDN
     */
-  lazy val onSubmit: EP[DomEvent] = eventProp("submit")
+  lazy val onSubmit: EP[DomEvent with DomElementTargetEvent] = eventProp("submit")
 
   /**
     * The reset event is fired when a form is reset.
     *
     * MDN
     */
-  lazy val onReset: EP[DomEvent] = eventProp("reset")
+  lazy val onReset: EP[DomEvent with DomElementTargetEvent] = eventProp("reset")
 
   /**
     * Script to be run when an element is invalid
     */
-  lazy val onInvalid: EP[DomEvent] = eventProp("invalid")
+  lazy val onInvalid: EP[DomEvent with DomElementTargetEvent] = eventProp("invalid")
 
   /**
     * Fires when the user writes something in a search field (for <input="search">)
     */
-  lazy val onSearch: EP[DomEvent] = eventProp("search")
+  lazy val onSearch: EP[DomEvent with DomElementTargetEvent] = eventProp("search")
 }


### PR DESCRIPTION
Another approach on the handling of events with specific targets.

There are more than just `onChange` and `onInput`, so I have added an `ElementTargetEvent`: it has `def target: dom.Element` and exposes a `def targetValue: String` for accessing the text content. This can be used for all events, where we know a more precise type of the `EventTarget`.

For me, this handles most use cases and it is useful to have the `target` as an Element, so you can call methods like `focus`, `blur`, etc. You can also still add your `DomInputEvent`.

What do you think?