### PR TITLE
Default eventProps to simple scala-js-dom types

### DIFF
--- a/js/src/main/scala/com/raquo/domtypes/jsdom/defs/events/PageTransitionEvent.scala
+++ b/js/src/main/scala/com/raquo/domtypes/jsdom/defs/events/PageTransitionEvent.scala
@@ -4,7 +4,7 @@ import org.scalajs.dom
 
 import scala.scalajs.js
 
-//TODO: contribute to scala-js-dom with onpageshow/onpagehide methods
+// @TODO: contribute to scala-js-dom with onpageshow/onpagehide methods
 /** Page transition events fire when a webpage is being loaded or unloaded.
   *
   * See https://developer.mozilla.org/en-US/docs/Web/API/PageTransitionEvent

--- a/js/src/main/scala/com/raquo/domtypes/jsdom/defs/events/TypedTargetEvent.scala
+++ b/js/src/main/scala/com/raquo/domtypes/jsdom/defs/events/TypedTargetEvent.scala
@@ -6,6 +6,6 @@ import scala.scalajs.js
 
 /** Represents an event for which we know the exact type of `target`. */
 @js.native
-trait TypedTargetEvent[+E <: dom.EventTarget] extends dom.Event {
-  override def target: E = js.native
+trait TypedTargetEvent[+T <: dom.EventTarget] extends dom.Event {
+  override def target: T = js.native
 }

--- a/js/src/main/scala/com/raquo/domtypes/jsdom/defs/events/TypedTargetFocusEvent.scala
+++ b/js/src/main/scala/com/raquo/domtypes/jsdom/defs/events/TypedTargetFocusEvent.scala
@@ -1,0 +1,10 @@
+package com.raquo.domtypes.jsdom.defs.events
+
+import org.scalajs.dom
+
+import scala.scalajs.js
+
+@js.native
+trait TypedTargetFocusEvent[+T <: dom.EventTarget]
+  extends dom.FocusEvent
+  with TypedTargetEvent[T]

--- a/js/src/main/scala/com/raquo/domtypes/jsdom/defs/events/TypedTargetMouseEvent.scala
+++ b/js/src/main/scala/com/raquo/domtypes/jsdom/defs/events/TypedTargetMouseEvent.scala
@@ -1,0 +1,10 @@
+package com.raquo.domtypes.jsdom.defs.events
+
+import org.scalajs.dom
+
+import scala.scalajs.js
+
+@js.native
+trait TypedTargetMouseEvent[+T <: dom.EventTarget]
+  extends dom.MouseEvent
+  with TypedTargetEvent[T]

--- a/js/src/main/scala/com/raquo/domtypes/jsdom/defs/package.scala
+++ b/js/src/main/scala/com/raquo/domtypes/jsdom/defs/package.scala
@@ -1,7 +1,7 @@
 package com.raquo.domtypes.jsdom
 
 import com.raquo.domtypes.generic
-import com.raquo.domtypes.jsdom.defs.events.{TypedTargetEvent, PageTransitionEvent}
+import com.raquo.domtypes.jsdom.defs.events.{PageTransitionEvent, TypedTargetEvent, TypedTargetFocusEvent, TypedTargetMouseEvent}
 import org.scalajs.dom
 
 package object defs {
@@ -12,7 +12,16 @@ package object defs {
 
     type ErrorEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.ErrorEventProps[EP, dom.Event, dom.ErrorEvent]
 
-    type FormEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.FormEventProps[EP, dom.Event, dom.FocusEvent, dom.Event, dom.Event, dom.Event, dom.Event, dom.Event]
+    type FormEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.FormEventProps[
+      EP,
+      dom.Event,
+      TypedTargetFocusEvent[dom.Element],
+      dom.Event,
+      TypedTargetEvent[dom.Element],
+      TypedTargetEvent[dom.html.Element],
+      TypedTargetEvent[dom.html.Form],
+      TypedTargetEvent[dom.html.Input]
+    ]
 
     type KeyboardEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.KeyboardEventProps[EP, dom.Event, dom.KeyboardEvent]
 
@@ -20,7 +29,13 @@ package object defs {
 
     type MiscellaneousEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.MiscellaneousEventProps[EP, dom.Event, dom.UIEvent]
 
-    type MouseEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.MouseEventProps[EP, dom.Event, dom.MouseEvent, dom.MouseEvent, dom.DragEvent]
+    type MouseEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.MouseEventProps[
+      EP,
+      dom.Event,
+      dom.MouseEvent,
+      TypedTargetMouseEvent[dom.Element],
+      dom.DragEvent
+    ]
 
     type WindowOnlyEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.WindowOnlyEventProps[
       EP,
@@ -60,58 +75,6 @@ package object defs {
     trait HTMLElementEventProps[EP[_ <: dom.Event]]
       extends ElementEventProps[EP]
       with ClipboardEventProps[EP] { this: generic.builders.EventPropBuilder[EP, dom.Event] => }
-  }
-
-  /** These event props have additional, more precise types that you can use instead of the types
-    * in the [[eventProps]] package above if you don't mind uglier type signatures.
-    */
-  object typedEventProps {
-
-    type FormEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.FormEventProps[
-      EP,
-      dom.Event,
-      dom.FocusEvent with TypedTargetEvent[dom.Element],
-      dom.Event,
-      TypedTargetEvent[dom.Element],
-      TypedTargetEvent[dom.html.Element],
-      TypedTargetEvent[dom.html.Form],
-      TypedTargetEvent[dom.html.Input]
-    ]
-
-    type MouseEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.MouseEventProps[
-      EP,
-      dom.Event,
-      dom.MouseEvent,
-      dom.MouseEvent with TypedTargetEvent[dom.Element],
-      dom.DragEvent
-    ]
-
-    // See this comment thread for examples on how to use the traits below: https://github.com/raquo/scala-dom-types/pull/9#discussion_r151857048
-
-    /** Matches GlobalEventHandlers: https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers */
-    trait GlobalEventProps[EP[_ <: dom.Event]]
-      extends eventProps.ErrorEventProps[EP]
-      with FormEventProps[EP]
-      with eventProps.KeyboardEventProps[EP]
-      with eventProps.MediaEventProps[EP]
-      with eventProps.MiscellaneousEventProps[EP]
-      with MouseEventProps[EP] { this: generic.builders.EventPropBuilder[EP, dom.Event] => }
-
-    /** Matches WindowEventHandlers: https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers */
-    trait WindowEventProps[EP[_ <: dom.Event]]
-      extends GlobalEventProps[EP]
-      with eventProps.WindowOnlyEventProps[EP] { this: generic.builders.EventPropBuilder[EP, dom.Event] => }
-
-    trait DocumentEventProps[EP[_ <: dom.Event]]
-      extends GlobalEventProps[EP]
-      with eventProps.ClipboardEventProps[EP] { this: generic.builders.EventPropBuilder[EP, dom.Event] => }
-
-    trait ElementEventProps[EP[_ <: dom.Event]]
-      extends GlobalEventProps[EP] { this: generic.builders.EventPropBuilder[EP, dom.Event] => }
-
-    trait HTMLElementEventProps[EP[_ <: dom.Event]]
-      extends ElementEventProps[EP]
-      with eventProps.ClipboardEventProps[EP] { this: generic.builders.EventPropBuilder[EP, dom.Event] => }
   }
 
   object tags {

--- a/js/src/main/scala/com/raquo/domtypes/jsdom/defs/package.scala
+++ b/js/src/main/scala/com/raquo/domtypes/jsdom/defs/package.scala
@@ -7,24 +7,111 @@ import org.scalajs.dom
 package object defs {
 
   object eventProps {
+
     type ClipboardEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.ClipboardEventProps[EP, dom.Event, dom.ClipboardEvent]
+
     type ErrorEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.ErrorEventProps[EP, dom.Event, dom.ErrorEvent]
-    type FormEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.FormEventProps[EP, dom.Event, dom.FocusEvent, dom.Event, TypedTargetEvent[dom.Element], TypedTargetEvent[dom.html.Element], TypedTargetEvent[dom.html.Form], TypedTargetEvent[dom.html.Input]]
+
+    type FormEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.FormEventProps[EP, dom.Event, dom.FocusEvent, dom.Event, dom.Event, dom.Event, dom.Event, dom.Event]
+
     type KeyboardEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.KeyboardEventProps[EP, dom.Event, dom.KeyboardEvent]
+
     type MediaEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.MediaEventProps[EP, dom.Event]
+
     type MiscellaneousEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.MiscellaneousEventProps[EP, dom.Event, dom.UIEvent]
-    type MouseEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.MouseEventProps[EP, dom.Event, dom.MouseEvent, dom.DragEvent, TypedTargetEvent[dom.Element]]
-    type WindowOnlyEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.WindowOnlyEventProps[EP, dom.Event, dom.UIEvent, dom.BeforeUnloadEvent, dom.HashChangeEvent, dom.MessageEvent, PageTransitionEvent, dom.PopStateEvent, dom.StorageEvent]
+
+    type MouseEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.MouseEventProps[EP, dom.Event, dom.MouseEvent, dom.MouseEvent, dom.DragEvent]
+
+    type WindowOnlyEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.WindowOnlyEventProps[
+      EP,
+      dom.Event,
+      dom.UIEvent,
+      dom.BeforeUnloadEvent,
+      dom.HashChangeEvent,
+      dom.MessageEvent,
+      PageTransitionEvent, // @TODO contribute this type to scala-js-dom
+      dom.PopStateEvent,
+      dom.StorageEvent
+    ]
 
     // See this comment thread for examples on how to use the traits below: https://github.com/raquo/scala-dom-types/pull/9#discussion_r151857048
 
     /** Matches GlobalEventHandlers: https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers */
-    trait GlobalEventProps[EP[_ <: dom.Event]] extends ErrorEventProps[EP] with FormEventProps[EP] with KeyboardEventProps[EP] with MediaEventProps[EP] with MiscellaneousEventProps[EP] with MouseEventProps[EP] { this: generic.builders.EventPropBuilder[EP, dom.Event] => }
+    trait GlobalEventProps[EP[_ <: dom.Event]]
+      extends ErrorEventProps[EP]
+      with FormEventProps[EP]
+      with KeyboardEventProps[EP]
+      with MediaEventProps[EP]
+      with MiscellaneousEventProps[EP]
+      with MouseEventProps[EP] { this: generic.builders.EventPropBuilder[EP, dom.Event] => }
+
     /** Matches WindowEventHandlers: https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers */
-    trait WindowEventProps[EP[_ <: dom.Event]] extends GlobalEventProps[EP] with WindowOnlyEventProps[EP] { this: generic.builders.EventPropBuilder[EP, dom.Event] => }
-    trait DocumentEventProps[EP[_ <: dom.Event]] extends GlobalEventProps[EP] with ClipboardEventProps[EP] { this: generic.builders.EventPropBuilder[EP, dom.Event] => }
-    trait ElementEventProps[EP[_ <: dom.Event]] extends GlobalEventProps[EP] { this: generic.builders.EventPropBuilder[EP, dom.Event] => }
-    trait HTMLElementEventProps[EP[_ <: dom.Event]] extends ElementEventProps[EP] with ClipboardEventProps[EP] { this: generic.builders.EventPropBuilder[EP, dom.Event] => }
+    trait WindowEventProps[EP[_ <: dom.Event]]
+      extends GlobalEventProps[EP]
+      with WindowOnlyEventProps[EP] { this: generic.builders.EventPropBuilder[EP, dom.Event] => }
+
+    trait DocumentEventProps[EP[_ <: dom.Event]]
+      extends GlobalEventProps[EP]
+      with ClipboardEventProps[EP] { this: generic.builders.EventPropBuilder[EP, dom.Event] => }
+
+    trait ElementEventProps[EP[_ <: dom.Event]]
+      extends GlobalEventProps[EP] { this: generic.builders.EventPropBuilder[EP, dom.Event] => }
+
+    trait HTMLElementEventProps[EP[_ <: dom.Event]]
+      extends ElementEventProps[EP]
+      with ClipboardEventProps[EP] { this: generic.builders.EventPropBuilder[EP, dom.Event] => }
+  }
+
+  /** These event props have additional, more precise types that you can use instead of the types
+    * in the [[eventProps]] package above if you don't mind uglier type signatures.
+    */
+  object typedEventProps {
+
+    type FormEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.FormEventProps[
+      EP,
+      dom.Event,
+      dom.FocusEvent with TypedTargetEvent[dom.Element],
+      dom.Event,
+      TypedTargetEvent[dom.Element],
+      TypedTargetEvent[dom.html.Element],
+      TypedTargetEvent[dom.html.Form],
+      TypedTargetEvent[dom.html.Input]
+    ]
+
+    type MouseEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.MouseEventProps[
+      EP,
+      dom.Event,
+      dom.MouseEvent,
+      dom.MouseEvent with TypedTargetEvent[dom.Element],
+      dom.DragEvent
+    ]
+
+    // See this comment thread for examples on how to use the traits below: https://github.com/raquo/scala-dom-types/pull/9#discussion_r151857048
+
+    /** Matches GlobalEventHandlers: https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers */
+    trait GlobalEventProps[EP[_ <: dom.Event]]
+      extends eventProps.ErrorEventProps[EP]
+      with FormEventProps[EP]
+      with eventProps.KeyboardEventProps[EP]
+      with eventProps.MediaEventProps[EP]
+      with eventProps.MiscellaneousEventProps[EP]
+      with MouseEventProps[EP] { this: generic.builders.EventPropBuilder[EP, dom.Event] => }
+
+    /** Matches WindowEventHandlers: https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers */
+    trait WindowEventProps[EP[_ <: dom.Event]]
+      extends GlobalEventProps[EP]
+      with eventProps.WindowOnlyEventProps[EP] { this: generic.builders.EventPropBuilder[EP, dom.Event] => }
+
+    trait DocumentEventProps[EP[_ <: dom.Event]]
+      extends GlobalEventProps[EP]
+      with eventProps.ClipboardEventProps[EP] { this: generic.builders.EventPropBuilder[EP, dom.Event] => }
+
+    trait ElementEventProps[EP[_ <: dom.Event]]
+      extends GlobalEventProps[EP] { this: generic.builders.EventPropBuilder[EP, dom.Event] => }
+
+    trait HTMLElementEventProps[EP[_ <: dom.Event]]
+      extends ElementEventProps[EP]
+      with eventProps.ClipboardEventProps[EP] { this: generic.builders.EventPropBuilder[EP, dom.Event] => }
   }
 
   object tags {

--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/eventProps/FormEventProps.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/eventProps/FormEventProps.scala
@@ -22,7 +22,16 @@ import com.raquo.domtypes.generic.builders.EventPropBuilder
   *            DOM InputEvent https://developer.mozilla.org/en-US/docs/Web/API/InputEvent
   *            Note: This type is not implemented in scala-js-dom
   */
-trait FormEventProps[EP[_ <: DomEvent], DomEvent, DomFocusEvent <: DomEvent, DomInputEvent <: DomEvent, DomElementTargetEvent <: DomEvent, DomHtmlElementTargetEvent <: DomEvent, DomFormElementTargetEvent <: DomEvent, DomInputElementTargetEvent <: DomEvent] { this: EventPropBuilder[EP, DomEvent] =>
+trait FormEventProps[
+  EP[_ <: DomEvent],
+  DomEvent,
+  DomElementFocusEvent <: DomElementTargetEvent,
+  DomInputEvent <: DomEvent,
+  DomElementTargetEvent <: DomEvent,
+  DomHtmlElementTargetEvent <: DomEvent,
+  DomFormElementTargetEvent <: DomEvent,
+  DomInputElementTargetEvent <: DomEvent
+] { this: EventPropBuilder[EP, DomEvent] =>
 
   /**
     * The change event is fired for input, select, and textarea elements
@@ -51,15 +60,14 @@ trait FormEventProps[EP[_ <: DomEvent], DomEvent, DomFocusEvent <: DomEvent, Dom
     *
     * MDN
     */
-  lazy val onBlur: EP[DomFocusEvent with DomElementTargetEvent] = eventProp("blur")
-
+  lazy val onBlur: EP[DomElementFocusEvent] = eventProp("blur")
 
   /**
     * The focus event is raised when the user sets focus on the given element.
     *
     * MDN
     */
-  lazy val onFocus: EP[DomFocusEvent with DomElementTargetEvent] = eventProp("focus")
+  lazy val onFocus: EP[DomElementFocusEvent] = eventProp("focus")
 
   /**
     * The submit event is fired when the user clicks a submit button in a form

--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/eventProps/MouseEventProps.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/eventProps/MouseEventProps.scala
@@ -4,11 +4,17 @@ import com.raquo.domtypes.generic.builders.EventPropBuilder
 
 /**
   * Mouse Events: triggered by a mouse, or similar user actions.
-  * @tparam DomElementTargetEvent
-  *            An event that has an Element as `target`.
+  * @tparam DomElementMouseEvent
+  *            A DomMouseEvent that has an Element as `target`.
   *            This event type has no corresponding type in JS DOM. See our own `TypedTargetEvent` trait.
   */
-trait MouseEventProps[EP[_ <: DomEvent], DomEvent, DomMouseEvent <: DomEvent, DomDragEvent <: DomMouseEvent, DomElementTargetEvent <: DomEvent] { this: EventPropBuilder[EP, DomEvent] =>
+trait MouseEventProps[
+  EP[_ <: DomEvent],
+  DomEvent,
+  DomMouseEvent <: DomEvent,
+  DomElementMouseEvent <: DomMouseEvent,
+  DomDragEvent <: DomMouseEvent
+] { this: EventPropBuilder[EP, DomEvent] =>
 
   /**
     * The click event is raised when the user clicks on an element. The click
@@ -16,7 +22,7 @@ trait MouseEventProps[EP[_ <: DomEvent], DomEvent, DomMouseEvent <: DomEvent, Do
     *
     * MDN
     */
-  lazy val onClick: EP[DomMouseEvent with DomElementTargetEvent] = eventProp("click")
+  lazy val onClick: EP[DomElementMouseEvent] = eventProp("click")
 
   /**
     * The dblclick event is fired when a pointing device button (usually a
@@ -24,21 +30,21 @@ trait MouseEventProps[EP[_ <: DomEvent], DomEvent, DomMouseEvent <: DomEvent, Do
     *
     * MDN
     */
-  lazy val onDblClick: EP[DomMouseEvent with DomElementTargetEvent] = eventProp("dblclick")
+  lazy val onDblClick: EP[DomElementMouseEvent] = eventProp("dblclick")
 
   /**
     * The mousedown event is raised when the user presses the mouse button.
     *
     * MDN
     */
-  lazy val onMouseDown: EP[DomMouseEvent with DomElementTargetEvent] = eventProp("mousedown")
+  lazy val onMouseDown: EP[DomElementMouseEvent] = eventProp("mousedown")
 
   /**
     * The mousemove event is raised when the user moves the mouse.
     *
     * MDN
     */
-  lazy val onMouseMove: EP[DomMouseEvent with DomElementTargetEvent] = eventProp("mousemove")
+  lazy val onMouseMove: EP[DomElementMouseEvent] = eventProp("mousemove")
 
   /**
     * The mouseout event is raised when the mouse leaves an element (e.g, when
@@ -47,7 +53,7 @@ trait MouseEventProps[EP[_ <: DomEvent], DomEvent, DomMouseEvent <: DomEvent, Do
     *
     * MDN
     */
-  lazy val onMouseOut: EP[DomMouseEvent with DomElementTargetEvent] = eventProp("mouseout")
+  lazy val onMouseOut: EP[DomElementMouseEvent] = eventProp("mouseout")
 
   /**
     * The mouseover event is raised when the user moves the mouse over a
@@ -55,7 +61,7 @@ trait MouseEventProps[EP[_ <: DomEvent], DomEvent, DomMouseEvent <: DomEvent, Do
     *
     * MDN
     */
-  lazy val onMouseOver: EP[DomMouseEvent with DomElementTargetEvent] = eventProp("mouseover")
+  lazy val onMouseOver: EP[DomElementMouseEvent] = eventProp("mouseover")
 
 
   /**
@@ -70,7 +76,7 @@ trait MouseEventProps[EP[_ <: DomEvent], DomEvent, DomMouseEvent <: DomEvent, Do
     *
     * MDN
     */
-  lazy val onMouseLeave: EP[DomMouseEvent with DomElementTargetEvent] = eventProp("mouseleave")
+  lazy val onMouseLeave: EP[DomElementMouseEvent] = eventProp("mouseleave")
 
 
   /**
@@ -85,14 +91,14 @@ trait MouseEventProps[EP[_ <: DomEvent], DomEvent, DomMouseEvent <: DomEvent, Do
     *
     * MDN
     */
-  lazy val onMouseEnter: EP[DomMouseEvent with DomElementTargetEvent] = eventProp("mouseenter")
+  lazy val onMouseEnter: EP[DomElementMouseEvent] = eventProp("mouseenter")
 
   /**
     * The mouseup event is raised when the user releases the mouse button.
     *
     * MDN
     */
-  lazy val onMouseUp: EP[DomMouseEvent with DomElementTargetEvent] = eventProp("mouseup")
+  lazy val onMouseUp: EP[DomElementMouseEvent] = eventProp("mouseup")
 
   /**
     * Fires when the mouse wheel rolls up or down over an element


### PR DESCRIPTION
I tried using SDT in a project where I have no use for `TypedTargetEvent`, and it was quite annoying to deal with those types. It was confusing both myself (harder to grasp, somewhat misleading compiler errors) and the IDE (I blame the IDE but still), and required me to write SDT-specific type signatures in end user (non-framework) code instead of simple e.g. `dom.MouseEvent`.

All in all, I don't think it's right to throw this experience onto developers who did not yet face the `target` problem in the first place, nevermind decided to use the SDT solution to it. What's bothering me most is that using those types requires extra knowledge of SDT types in addition to scala-js-dom.

So, I moved the fancy types into a new `typedEventProps` package, and populated the `eventProps` package with basic versions. Migration for Outwatch should consist of just referencing this new package for all the types that are defined in it.

I did change the signatures of a couple `generic` traits as well but it should not matter unless you are referencing those generic traits directly.

I am not a fan of keeping two versions of essentially the same types in SDT, but now I am curious to see which option gets more traction.

cc @cornerman