### PR TITLE
add innerHTML property

### DIFF
--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/props/Props.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/props/Props.scala
@@ -48,4 +48,11 @@ trait Props[P[_, _]] { this: PropBuilder[P] =>
     * See also [[com.raquo.domtypes.generic.defs.reflectedAttrs.ReflectedAttrs.defaultValue]]
     */
   lazy val value: P[String, String] = stringProp("value")
+
+  /**
+    * The Element.innerHTML property sets or gets the HTML syntax describing the element's descendants.
+    *
+    * MDN
+    */
+  lazy val innerHTML: P[String, String] = stringProp("innerHTML")
 }


### PR DESCRIPTION
This adds the `innerHTML` property, which is useful for feeding raw html into an element. For example, when using a markdown parser and writing the generated html.