### PR TITLE
SVG Support

### DIFF
--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/attrs/svgAttrs.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/attrs/svgAttrs.scala
@@ -1,0 +1,45 @@
+
+package com.raquo.domtypes.generic.defs.attrs
+
+import com.raquo.domtypes.generic.builders.AttrBuilder
+import com.raquo.domtypes.generic.codecs.{BooleanAsOnOffStringCodec, BooleanAsTrueFalseStringCodec}
+
+/** @tparam A HTML Attribute, canonically [[com.raquo.domtypes.generic.keys.Attr]] */
+trait Attrs[A[_]] { this: AttrBuilder[A] =>
+  /**
+   * This attribute defines the distance from the origin to the top of accent characters,
+   * measured by a distance within the font coordinate system.
+   * If the attribute is not specified, the effect is as if the attribute
+   * were set to the value of the ascent attribute.
+   *
+   * Value 	<number>
+   *
+   * MDN
+   */
+  lazy val accentHeight = stringAttr("accent-height")
+
+  /**
+   * This attribute controls whether or not the animation is cumulative.
+   * It is frequently useful for repeated animations to build upon the previous results,
+   * accumulating with each iteration. This attribute said to the animation if the value is added to
+   * the previous animated attribute's value on each iteration.
+   *
+   * Value 	none | sum
+   *
+   * MDN
+   */
+  lazy val accumulate = stringAttr("accumulate")
+
+  /**
+   * This attribute controls whether or not the animation is additive.
+   * It is frequently useful to define animation as an offset or delta
+   * to an attribute's value, rather than as absolute values. This
+   * attribute said to the animation if their values are added to the
+   * original animated attribute's value.
+   *
+   * Value 	replace | sum
+   *
+   * MDN
+   */
+
+}

--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/attrs/svgAttrs.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/attrs/svgAttrs.scala
@@ -5,7 +5,7 @@ import com.raquo.domtypes.generic.builders.AttrBuilder
 import com.raquo.domtypes.generic.codecs.{BooleanAsOnOffStringCodec, BooleanAsTrueFalseStringCodec}
 
 /** @tparam A HTML Attribute, canonically [[com.raquo.domtypes.generic.keys.Attr]] */
-trait Attrs[A[_]] { this: AttrBuilder[A] =>
+trait svgAttrs[A[_]] { this: AttrBuilder[A] =>
   /**
    * This attribute defines the distance from the origin to the top of accent characters,
    * measured by a distance within the font coordinate system.


### PR DESCRIPTION
For reference:
* https://developer.mozilla.org/en-US/docs/Web/SVG
* SVG-Tags in scalatags with MDN documentation:
  https://github.com/lihaoyi/scalatags/blob/44cbd0602d40186d33d39b8d4a259f681d2e4a3b/scalatags/shared/src/main/scala/scalatags/generic/SvgTags.scala
* SVG tag to dom-type association in scalatags
  https://github.com/lihaoyi/scalatags/blob/44cbd0602d40186d33d39b8d4a259f681d2e4a3b/scalatags/js/src/main/scala/scalatags/jsdom/SvgTags.scala

- [ ] Create generic `svg/Attrs.scala` trait with typed listings of SVG attributes
- [x] Same for `svg/Tags.scala` (might need multiple files similar to how HTML tags are done)
- [ ] Add JS-specific type aliases of the above to `jsdom/defs/package.scala`
- [ ] Probably need a new key class: `SvgAttr` (I don't _think_ we should reuse Attr for that), and a canonical builder for it (see `canonical` dir). Don't want to accidentally use SVG attrs on HTML elements, and without #13 not sure what else we can do. Not sure about this, and IIRC you're not using these concrete classes in Outwatch, so I guess I'll need to think about this some time later.
- [ ] For the `Tag` class, I _think_ no need to create `SvgTag`, maybe Tag[SVGElement] would be enough. Not sure.
- [ ] Lastly, we'd need to add SVG to the bundle in CompileTest. I think I'm ok allowing naming collisions between SVG and HTML, since most librarries will probably choose to namespace everything svg-related. Things within SVG should probably be free of collisions and follow the same [naming guidelines](https://github.com/raquo/scala-dom-types#sanity-preservation-measures) as our HTML stuff
- [ ] SVG Namespaces?


fixes #20 