### PR TITLE
make autocomplete attribute accept string instead of boolean

### DIFF
--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/reflectedAttrs/ReflectedAttrs.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/reflectedAttrs/ReflectedAttrs.scala
@@ -78,12 +78,7 @@ trait ReflectedAttrs[RA[_, _]] { this: ReflectedAttrBuilder[RA] =>
     *
     * MDN
     */
-  lazy val autoComplete: RA[Boolean, String] = reflectedAttr(
-    attrKey = "autocomplete",
-    propKey = "autocomplete",
-    attrCodec = BooleanAsOnOffStringCodec,
-    propCodec = BooleanAsOnOffStringCodec
-  )
+  lazy val autoComplete: RA[String, String] = stringReflectedAttr("autocomplete")
 
   /**
     * This Boolean attribute lets you specify that a form control should have


### PR DESCRIPTION
Just stumbled over the `autocomplete` attribute, which currently just accepts boolean, which are converted to "off/on" values. This is correct for form elements, but input elements accept many more options.

I could not find a proper documentation, but possible values are listed [on mdn](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input) (search for autocomplete). Maybe also relevant: https://www.chromium.org/developers/design-documents/create-amazing-password-forms.