### PR TITLE
Naming: Add `Html` prefix to a bunch of traits and objects for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ The following allowances for breaking changes exist _for now_:
 
 TODO: Adopt more mature versioning, eventually. Read about eviction, binary compatibility, etc.
 
-#### v0.8 – TBD
+#### v0.8 – Aug 2018
 
 * **New: Add `namespace` param to `SvgAttr`**
 * **Naming: `xlink` -> `xlinkRole` to match native attribute name**
+* **Naming: Add `Html` to various traits that deal with HTML attributes**
 
 #### v0.7.1 – Jul 2018
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 _Scala DOM Types_ provides listings and type definitions for Javascript HTML and SVG tags as well as their attributes, DOM properties, and CSS styles.
 
-    "com.raquo" %%% "domtypes" % "0.7.1"    // scala.js
-    "com.raquo" %% "domtypes" % "0.7.1"     // JVM
+    "com.raquo" %%% "domtypes" % "0.8"    // scala.js
+    "com.raquo" %% "domtypes" % "0.8"     // JVM
 
 Our type definitions are designed for easy integration into any kind of library. You can use this project to build your own DOM libraries like React or Snabbdom, but type-safe. For example, popular Scala.js reactive UI library [Outwatch](https://github.com/OutWatch/outwatch/) recently switched to _Scala DOM Types_, offloading thousands of lines of code and improving type safety ([diff](https://github.com/OutWatch/outwatch/pull/62)). I am also using _Scala DOM Types_ in my own projects:
 
@@ -182,9 +182,9 @@ HTML attributes and DOM properties are different things. As a prerequisite for t
 
 For more on this, read [Section 2.6.1 of this DOM spec](https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflecting-content-attributes-in-idl-attributes). Note that it uses the term "IDL attributes" to refer to what we call "DOM properties", and "Content attributes" to refer to what we here call "HTML attributes".
 
-So with that knowledge, `id` for example is a reflected attribute. Setting and reading it works exactly the same way regardless of whether you're using the HTML attribute `id`, or the DOM property `id`. Such reflected attributes live in `ReflectedAttrs` trait, which lets you build either attributes or properties depending on what implementation of `ReflectedAttrBuilder` you provide.
+So with that knowledge, `id` for example is a reflected attribute. Setting and reading it works exactly the same way regardless of whether you're using the HTML attribute `id`, or the DOM property `id`. Such reflected attributes live in `ReflectedHtmlAttrs` trait, which lets you build either attributes or properties depending on what implementation of `ReflectedHtmlAttrBuilder` you provide.
 
-To keep you sane, _Scala DOM Types_ reflected attributes also normalize the DOM API a bit. For example, there is no `value` attribute in _Scala DOM Types_. There is only `defaultValue` reflected attribute, which uses either the `value` HTML attribute or the `defaultValue` DOM property depending on how you implement `ReflectedAttrBuilder`. This is because that attribute and that property behave the same even though they're named differently in the DOM, whereas the `value` DOM property has different behaviour (see the StackOverflow answer linked above). A corresponding HTML attribute with such behaviour does not exist, so in Scala DOM Types the `value` prop is defined in trait `Props`. It is not an attribute, nor is it a a reflected attribute.
+To keep you sane, _Scala DOM Types_ reflected attributes also normalize the DOM API a bit. For example, there is no `value` attribute in _Scala DOM Types_. There is only `defaultValue` reflected attribute, which uses either the `value` HTML attribute or the `defaultValue` DOM property depending on how you implement `ReflectedHtmlAttrBuilder`. This is because that attribute and that property behave the same even though they're named differently in the DOM, whereas the `value` DOM property has different behaviour (see the StackOverflow answer linked above). A corresponding HTML attribute with such behaviour does not exist, so in Scala DOM Types the `value` prop is defined in trait `Props`. It is not an attribute, nor is it a a reflected attribute.
 
 Reflected attributes may behave slightly differently depending on whether you implement them as props or attributes. For example, in HTML5 the `cols` reflected attribute has a default value of `20`. If you read the `col` property fro man empty `<textarea>` element, you will get `20`. However, if you try to read the attribute `col`, you will get nothing because the attribute was never explicitly set.
 

--- a/js/src/test/scala/com/raquo/domtypes/CompileTest.scala
+++ b/js/src/test/scala/com/raquo/domtypes/CompileTest.scala
@@ -1,11 +1,11 @@
 package com.raquo.domtypes
 
-import com.raquo.domtypes.generic.builders.canonical.CanonicalReflectedAttrBuilder.ReflectedAttr
-import com.raquo.domtypes.generic.builders.canonical.{CanonicalEventPropBuilder, CanonicalHtmlAttrBuilder, CanonicalPropBuilder, CanonicalReflectedAttrBuilder, CanonicalSvgAttrBuilder}
+import com.raquo.domtypes.generic.builders.canonical.CanonicalReflectedHtmlAttrBuilder.ReflectedAttr
+import com.raquo.domtypes.generic.builders.canonical.{CanonicalEventPropBuilder, CanonicalHtmlAttrBuilder, CanonicalPropBuilder, CanonicalReflectedHtmlAttrBuilder, CanonicalSvgAttrBuilder}
 import com.raquo.domtypes.generic.builders.{HtmlTagBuilder, StyleBuilders, SvgTagBuilder, Tag}
-import com.raquo.domtypes.generic.defs.attrs.{AriaAttrs, Attrs, SvgAttrs}
+import com.raquo.domtypes.generic.defs.attrs.{AriaAttrs, HtmlAttrs, SvgAttrs}
 import com.raquo.domtypes.generic.defs.props.Props
-import com.raquo.domtypes.generic.defs.reflectedAttrs.ReflectedAttrs
+import com.raquo.domtypes.generic.defs.reflectedAttrs.ReflectedHtmlAttrs
 import com.raquo.domtypes.generic.defs.styles.{Styles, Styles2}
 import com.raquo.domtypes.generic.keys.{EventProp, HtmlAttr, Prop, Style, SvgAttr}
 import com.raquo.domtypes.jsdom.defs.eventProps.{ClipboardEventProps, DocumentOnlyEventProps, ErrorEventProps, FormEventProps, HTMLElementEventProps, KeyboardEventProps, MediaEventProps, MiscellaneousEventProps, MouseEventProps, WindowOnlyEventProps}
@@ -35,7 +35,7 @@ class CompileTest {
 
   object Bundle
     // Attrs
-    extends Attrs[HtmlAttr]
+    extends HtmlAttrs[HtmlAttr]
     with AriaAttrs[HtmlAttr]
     // Event Props
     with ClipboardEventProps[EventProp]
@@ -50,7 +50,7 @@ class CompileTest {
     // Props
     with Props[Prop]
     // Reflected Attrs
-    with ReflectedAttrs[ReflectedAttr]
+    with ReflectedHtmlAttrs[ReflectedAttr]
     // Styles
     with Styles[SomeStyleSetter]
     with Styles2[SomeStyleSetter]
@@ -65,7 +65,7 @@ class CompileTest {
     with TextTags[Tag]
     // Concrete Builders
     with CanonicalHtmlAttrBuilder
-    with CanonicalReflectedAttrBuilder
+    with CanonicalReflectedHtmlAttrBuilder
     with CanonicalEventPropBuilder[dom.Event]
     with CanonicalPropBuilder
     with CanonicalSvgAttrBuilder // Not needed but want to ensure compatibility

--- a/shared/src/main/scala/com/raquo/domtypes/generic/builders/ReflectedHtmlAttrBuilder.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/builders/ReflectedHtmlAttrBuilder.scala
@@ -7,7 +7,7 @@ import com.raquo.domtypes.generic.codecs.{BooleanAsIsCodec, Codec, DoubleAsIsCod
   *
   * Reflected attributes are explained in the README file.
   *
-  * Also see [[com.raquo.domtypes.generic.defs.reflectedAttrs.ReflectedAttrs]] for a summary of
+  * Also see [[com.raquo.domtypes.generic.defs.reflectedAttrs.ReflectedHtmlAttrs]] for a summary of
   * reflected attributes. Basically it's a subset of HTML attributes that are fully mirrored
   * as DOM properties, so typically you don't want to load both an attribute and a property
   * of the same name.
@@ -17,7 +17,7 @@ import com.raquo.domtypes.generic.codecs.{BooleanAsIsCodec, Codec, DoubleAsIsCod
   *            or [[com.raquo.domtypes.generic.keys.Prop]] depending on whether you want to build
   *            properties or attributes
   */
-trait ReflectedAttrBuilder[RA[_, _]] {
+trait ReflectedHtmlAttrBuilder[RA[_, _]] {
 
   /** Create a reflected attribute */
   @inline protected def reflectedAttr[V, DomPropV](

--- a/shared/src/main/scala/com/raquo/domtypes/generic/builders/canonical/CanonicalReflectedHtmlAttrBuilder.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/builders/canonical/CanonicalReflectedHtmlAttrBuilder.scala
@@ -1,20 +1,20 @@
 package com.raquo.domtypes.generic.builders.canonical
 
-import com.raquo.domtypes.generic.builders.ReflectedAttrBuilder
-import com.raquo.domtypes.generic.builders.canonical.CanonicalReflectedAttrBuilder.ReflectedAttr
+import com.raquo.domtypes.generic.builders.ReflectedHtmlAttrBuilder
+import com.raquo.domtypes.generic.builders.canonical.CanonicalReflectedHtmlAttrBuilder.ReflectedAttr
 import com.raquo.domtypes.generic.codecs.Codec
 import com.raquo.domtypes.generic.keys.HtmlAttr
 
-/** Canonical implementation of [[ReflectedAttrBuilder]], using our own [[HtmlAttr]] class.
+/** Canonical implementation of [[ReflectedHtmlAttrBuilder]], using our own [[HtmlAttr]] class.
   *
   * If you are using this implementation, create an implicit value class
   * around [[HtmlAttr]] – there you can e.g. implement the `:=` method.
   *
   * Alternatively, you can use [[CanonicalReflectedPropBuilder]], or implement your own
-  * [[ReflectedAttrBuilder]] that uses either a subclass of either [[HtmlAttr]] or
+  * [[ReflectedHtmlAttrBuilder]] that uses either a subclass of either [[HtmlAttr]] or
   * [[com.raquo.domtypes.generic.keys.Prop]], or a completely unrelated type of your own.
   */
-trait CanonicalReflectedAttrBuilder extends ReflectedAttrBuilder[ReflectedAttr] {
+trait CanonicalReflectedHtmlAttrBuilder extends ReflectedHtmlAttrBuilder[ReflectedAttr] {
 
   override protected def reflectedAttr[V, DomPropV](
     attrKey: String,
@@ -29,7 +29,7 @@ trait CanonicalReflectedAttrBuilder extends ReflectedAttrBuilder[ReflectedAttr] 
   }
 }
 
-object CanonicalReflectedAttrBuilder {
+object CanonicalReflectedHtmlAttrBuilder {
 
   // @TODO[Integrity] We can't enforce that DomV is String here, but we know it from the DOM spec.
   /** All this type alias does is discard the DomV type param that is not used in Attrs. */

--- a/shared/src/main/scala/com/raquo/domtypes/generic/builders/canonical/CanonicalReflectedPropBuilder.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/builders/canonical/CanonicalReflectedPropBuilder.scala
@@ -1,19 +1,19 @@
 package com.raquo.domtypes.generic.builders.canonical
 
-import com.raquo.domtypes.generic.builders.ReflectedAttrBuilder
+import com.raquo.domtypes.generic.builders.ReflectedHtmlAttrBuilder
 import com.raquo.domtypes.generic.codecs.Codec
 import com.raquo.domtypes.generic.keys.Prop
 
-/** Canonical implementation of [[ReflectedAttrBuilder]], using our own [[Prop]] class.
+/** Canonical implementation of [[ReflectedHtmlAttrBuilder]], using our own [[Prop]] class.
   *
   * If you are using this implementation, create an implicit value class
   * around [[Prop]] – there you can e.g. implement the `:=` method.
   *
-  * Alternatively, you can use [[CanonicalReflectedAttrBuilder]], or implement your own
-  * [[ReflectedAttrBuilder]] that uses either a subclass of either [[Prop]] or
+  * Alternatively, you can use [[CanonicalReflectedHtmlAttrBuilder]], or implement your own
+  * [[ReflectedHtmlAttrBuilder]] that uses either a subclass of either [[Prop]] or
   * [[com.raquo.domtypes.generic.keys.HtmlAttr]], or a completely unrelated type of your own.
   */
-trait CanonicalReflectedPropBuilder extends ReflectedAttrBuilder[Prop] {
+trait CanonicalReflectedPropBuilder extends ReflectedHtmlAttrBuilder[Prop] {
 
   override protected def reflectedAttr[V, DomPropV](
     attrKey: String,

--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/attrs/HtmlAttrs.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/attrs/HtmlAttrs.scala
@@ -4,7 +4,7 @@ import com.raquo.domtypes.generic.builders.HtmlAttrBuilder
 import com.raquo.domtypes.generic.codecs.{BooleanAsOnOffStringCodec, BooleanAsTrueFalseStringCodec}
 
 /** @tparam A HTML Attribute, canonically [[com.raquo.domtypes.generic.keys.HtmlAttr]] */
-trait Attrs[A[_]] { this: HtmlAttrBuilder[A] =>
+trait HtmlAttrs[A[_]] { this: HtmlAttrBuilder[A] =>
 
   /**
     * Declares the character encoding of the page or script. Used on meta and

--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/props/Props.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/props/Props.scala
@@ -19,7 +19,7 @@ trait Props[P[_, _]] { this: PropBuilder[P] =>
     * When the value of the type attribute is "radio" or "checkbox", this property
     * determines whether it is checked or not.
     *
-    * See also [[com.raquo.domtypes.generic.defs.reflectedAttrs.ReflectedAttrs.defaultChecked]]
+    * See also [[com.raquo.domtypes.generic.defs.reflectedAttrs.ReflectedHtmlAttrs.defaultChecked]]
     */
   lazy val checked: P[Boolean, Boolean] = prop("checked", BooleanAsIsCodec)
 
@@ -36,7 +36,7 @@ trait Props[P[_, _]] { this: PropBuilder[P] =>
     * which contains the _initial_ selected status of the element.
     * More info: https://stackoverflow.com/a/6004028/2601788 (`selected` behaves similar to `value`)
     *
-    * See also [[com.raquo.domtypes.generic.defs.reflectedAttrs.ReflectedAttrs.defaultSelected]]
+    * See also [[com.raquo.domtypes.generic.defs.reflectedAttrs.ReflectedHtmlAttrs.defaultSelected]]
     */
   lazy val selected: P[Boolean, Boolean] = prop("selected", BooleanAsIsCodec)
 
@@ -45,7 +45,7 @@ trait Props[P[_, _]] { this: PropBuilder[P] =>
     * which contains the _initial_ value of the element.
     * More info: https://stackoverflow.com/a/6004028/2601788
     *
-    * See also [[com.raquo.domtypes.generic.defs.reflectedAttrs.ReflectedAttrs.defaultValue]]
+    * See also [[com.raquo.domtypes.generic.defs.reflectedAttrs.ReflectedHtmlAttrs.defaultValue]]
     */
   lazy val value: P[String, String] = stringProp("value")
 }

--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/reflectedAttrs/ReflectedHtmlAttrs.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/reflectedAttrs/ReflectedHtmlAttrs.scala
@@ -1,6 +1,6 @@
 package com.raquo.domtypes.generic.defs.reflectedAttrs
 
-import com.raquo.domtypes.generic.builders.ReflectedAttrBuilder
+import com.raquo.domtypes.generic.builders.ReflectedHtmlAttrBuilder
 import com.raquo.domtypes.generic.codecs.{BooleanAsAttrPresenceCodec, BooleanAsTrueFalseStringCodec, BooleanAsYesNoStringCodec, IterableAsSpaceSeparatedStringCodec}
 
 /**
@@ -17,12 +17,12 @@ import com.raquo.domtypes.generic.codecs.{BooleanAsAttrPresenceCodec, BooleanAsT
   * - https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflecting-content-attributes-in-idl-attributes
   *   (NOTE: The specification calls DOM properties "IDL attributes" and HTML attributes "Content attributes")
   *
-  * For type param docs, see [[ReflectedAttrBuilder]]
+  * For type param docs, see [[ReflectedHtmlAttrBuilder]]
   *
   * @tparam RA Reflected Attribute, canonically either [[com.raquo.domtypes.generic.keys.Prop]]
   *            or a type alias to [[com.raquo.domtypes.generic.keys.HtmlAttr]] (to remove the extra type param)
   */
-trait ReflectedAttrs[RA[_, _]] { this: ReflectedAttrBuilder[RA] =>
+trait ReflectedHtmlAttrs[RA[_, _]] { this: ReflectedHtmlAttrBuilder[RA] =>
 
   /**
     * If the value of the type attribute is file, this attribute indicates the


### PR DESCRIPTION
This needs a minor version bump so I'll wait until v0.8 to release it. Too lazy to use github milestones though.

I think ReflectedAttr* stuff also needs the HTML prefix as it's de facto specific to `HtmlAttr`, if we wanted a similar mechanism for `SvgAttr` it would need to be in separate files.