### PR TITLE
add missing svg attrs (refX,orient)

### DIFF
--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/attrs/SvgAttrs.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/attrs/SvgAttrs.scala
@@ -892,6 +892,13 @@ trait SvgAttrs[A[_]] { this: SvgAttrBuilder[A] =>
 
   lazy val offset: A[String] = stringSvgAttr("offset")
 
+    /**
+    * The ‘orient’ attribute indicates how the marker is rotated when it is placed at its position on the markable element.
+    *
+    * W3C
+    */
+  lazy val orient: A[String] = stringSvgAttr("orient")
+
   /**
     *
     *
@@ -1043,7 +1050,23 @@ trait SvgAttrs[A[_]] { this: SvgAttrBuilder[A] =>
     */
   lazy val radius: A[String] = stringSvgAttr("radius")
 
+  /**
+    * The ‘refX’ attribute defines the reference point of the marker which is to be placed exactly at
+    * the marker's position on the markable element. It is interpreted as being in the coordinate system of
+    * the marker contents, after application of the ‘viewBox’ and ‘preserveAspectRatio’ attributes.
+    *
+    *  W3C
+    */
+  lazy val refX: A[String] = stringSvgAttr("refX")
 
+  /**
+    * The ‘refY’ attribute defines the reference point of the marker which is to be placed exactly at
+    * the marker's position on the markable element. It is interpreted as being in the coordinate system of
+    * the marker contents, after application of the ‘viewBox’ and ‘preserveAspectRatio’ attributes.
+    *
+    *  W3C
+    */
+  lazy val refY: A[String] = stringSvgAttr("refY")
   /**
     *
     *


### PR DESCRIPTION
not sure why some attrs are missing ,here is a test

```scala

import com.raquo.laminar.api.L.svg._
object svgs {
  defs(
    marker(
      id := "",
      viewBox := "0 -5 10 10",
      refX := "4",
      markerWidth := "3",
      markerHeight := "3",
      orient := "auto",
      path(
        d := "M0,-5L10,0L0,5"
      )
    )
  )
}

```