### PR TITLE
New: Complex Keys (cls, rel, textContent, etc.)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ TODO: Adopt more mature versioning, eventually. Read about eviction, binary comp
 #### v0.9 – Sep 2018
 
 * **API: `AriaAttrs` now exposes attributes as members, without `aria` object**
-* **API: Move `cls`, `className`, `rel`, `styleAttr`, and `textContent` into new `ComplexHtmlKeys` and `ComplexSvgKeys` traits, allowing for more freedom to define these keys in non-standard ways. Use `CanonicalComplexHtmlKeys` and `CanonicalComplexSvgKeys` to retain v0.8 functionality**
-* **API: remove `classNames` reflected attribute. You can define it locally or use the new `ComplexHtmlKeys` functionality to get the desired API**
+* **API: Move `cls`, `className`, `rel`, `role`, and `styleAttr` into new `ComplexHtmlKeys` and `ComplexSvgKeys` traits, allowing for more freedom to define these keys in non-standard ways. Use `CanonicalComplexHtmlKeys` and `CanonicalComplexSvgKeys` to retain v0.8.1 functionality**
+* **API: Remove `textContent` property. See discussion in [#41](https://github.com/raquo/scala-dom-types/issues/41) and [#43](https://github.com/raquo/scala-dom-types/pull/43)**
+* **API: Remove `classNames` reflected attribute. You can define it locally or use the new `ComplexHtmlKeys` functionality to get the desired API**
 
 #### v0.8.1 – Sep 2018
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The following allowances for breaking changes exist _for now_:
 
 TODO: Adopt more mature versioning, eventually. Read about eviction, binary compatibility, etc.
 
+#### v0.9 – Sep 2018
+
+* **API: `AriaAttrs` now exposes attributes as members, without `aria` object**
+* **API: Move `cls`, `className`, `rel`, `styleAttr`, and `textContent` into new `ComplexHtmlKeys` and `ComplexSvgKeys` traits, allowing for more freedom to define these keys in non-standard ways. Use `CanonicalComplexHtmlKeys` and `CanonicalComplexSvgKeys` to retain v0.8 functionality**
+* **API: remove `classNames` reflected attribute. You can define it locally or use the new `ComplexHtmlKeys` functionality to get the desired API**
+
 #### v0.8.1 – Sep 2018
 
 * **Fix: `span`, `fontSizeAdjust`, `listStyleImage.none` should be `lazy val`s, not `def`s**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,4 +49,8 @@ These guidelines are for commit messages going into master. I think going forwar
 
 So far we are focused on HTML5 attributes and read-writeable DOM props, but it doesn't have to stay that way. There is value in providing listings for popular non-standard attributes as well (e.g. `autoCapitalize`, `unSelectable`) but we haven't decided how to deal with those yet. Don't hesitate to trigger this discussion though.
 
+Previous discussions:
+
+* `innerHTML` / `raw()` – [#21](https://github.com/raquo/scala-dom-types/pull/21), [#41](https://github.com/raquo/scala-dom-types/issues/41)
+
 As a workaround, you can always create custom attributes / props / etc. in your project, or publish e.g. a collection of attributes as a separate project.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ _Scala DOM Types_ is a low level library that is used by other libraries. As suc
 
 #### Sanity Preservation Measures
 
-We should provide a better API than the DOM if we can do that in a way that keeps usage discoverable and non-surprising.
+We should provide a better API than the DOM if we can do that in a way that keeps usage discoverable and unsurprising.
 
 Developers familiar with the DOM API should generally be able to discover the names of attributes / tags / etc. they need using IDE autocompletion (assuming they expect the names to match the DOM API). For example: `forId` is a good name for the `for` attribute. It avoids using a Scala reserved word, and it starts with `for` like the original attribute, so it's easy to find. It also implies what kind of string is expected for a value (an `id` of an element).
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 _Scala DOM Types_ provides listings and type definitions for Javascript HTML and SVG tags as well as their attributes, DOM properties, and CSS styles.
 
-    "com.raquo" %%% "domtypes" % "0.8.1"    // scala.js
-    "com.raquo" %% "domtypes" % "0.8.1"     // JVM
+    "com.raquo" %%% "domtypes" % "0.9"    // scala.js
+    "com.raquo" %% "domtypes" % "0.9"     // JVM
 
 Our type definitions are designed for easy integration into any kind of library. You can use this project to build your own DOM libraries like React or Snabbdom, but type-safe. For example, popular Scala.js reactive UI library [Outwatch](https://github.com/OutWatch/outwatch/) recently switched to _Scala DOM Types_, offloading thousands of lines of code and improving type safety ([diff](https://github.com/OutWatch/outwatch/pull/62)). I am also using _Scala DOM Types_ in my own projects:
 
@@ -27,6 +27,7 @@ Our type definitions are designed for easy integration into any kind of library.
 * [Documentation](#documentation)
   * [Codecs](#codecs)
   * [Reflected Attributes](#reflected-attributes)
+  * [Complex Keys](#complex-keys)
   * [DOM Events & `dom.Event.target`](#dom-events--domeventtarget)
   * [CSS](#css)
   * [SVG](#svg)
@@ -189,6 +190,13 @@ To keep you sane, _Scala DOM Types_ reflected attributes also normalize the DOM 
 Reflected attributes may behave slightly differently depending on whether you implement them as props or attributes. For example, in HTML5 the `cols` reflected attribute has a default value of `20`. If you read the `col` property fro man empty `<textarea>` element, you will get `20`. However, if you try to read the attribute `col`, you will get nothing because the attribute was never explicitly set.
 
 Note that Javascript DOM performs better for reading/writing DOM props than reading/writing HTML attributes.
+
+
+### Complex Keys
+
+Properties like `className` often require special handling in consuming libraries. For example, instead of a `String` based interface, you might want to offer a `Seq[String]` based one for `className`. To facilitate the development of such opinionated APIs we offer these keys in separate traits (`ComplexHtmlKeys` and `ComplexSvgKeys`) that allow for completely custom types.
+
+If you don't need such customization at all, just use `CanonicalComplexHtmlKeys` and `CanonicalComplexSvgKeys` traits which implement these keys similar to all the others.
 
 
 ### DOM Events & `dom.Event.target`

--- a/js/src/test/scala/com/raquo/domtypes/CompileTest.scala
+++ b/js/src/test/scala/com/raquo/domtypes/CompileTest.scala
@@ -4,6 +4,7 @@ import com.raquo.domtypes.generic.builders.canonical.CanonicalReflectedHtmlAttrB
 import com.raquo.domtypes.generic.builders.canonical.{CanonicalEventPropBuilder, CanonicalHtmlAttrBuilder, CanonicalPropBuilder, CanonicalReflectedHtmlAttrBuilder, CanonicalSvgAttrBuilder}
 import com.raquo.domtypes.generic.builders.{HtmlTagBuilder, StyleBuilders, SvgTagBuilder, Tag}
 import com.raquo.domtypes.generic.defs.attrs.{AriaAttrs, HtmlAttrs, SvgAttrs}
+import com.raquo.domtypes.generic.defs.complex.canonical.{CanonicalComplexHtmlKeys, CanonicalComplexSvgKeys}
 import com.raquo.domtypes.generic.defs.props.Props
 import com.raquo.domtypes.generic.defs.reflectedAttrs.ReflectedHtmlAttrs
 import com.raquo.domtypes.generic.defs.styles.{Styles, Styles2}
@@ -34,9 +35,9 @@ class CompileTest {
   }
 
   object Bundle
+    extends CanonicalComplexHtmlKeys[ReflectedAttr, HtmlAttr, Prop]
     // Attrs
-    extends HtmlAttrs[HtmlAttr]
-    with AriaAttrs[HtmlAttr]
+    with HtmlAttrs[HtmlAttr]
     // Event Props
     with ClipboardEventProps[EventProp]
     with ErrorEventProps[EventProp]
@@ -72,9 +73,14 @@ class CompileTest {
     with SomeStyleBuilders
     with SomeTagBuilders {
 
+    object aria
+      extends AriaAttrs[HtmlAttr]
+      with CanonicalHtmlAttrBuilder
+
     object svg
-      extends SvgAttrs[SvgAttr]
-      with SvgTags[Tag]
+      extends SvgTags[Tag]
+      with CanonicalComplexSvgKeys[SvgAttr]
+      with SvgAttrs[SvgAttr]
       with CanonicalSvgAttrBuilder
       with SomeTagBuilders
   }

--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/attrs/AriaAttrs.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/attrs/AriaAttrs.scala
@@ -3,308 +3,306 @@ package com.raquo.domtypes.generic.defs.attrs
 import com.raquo.domtypes.generic.builders.HtmlAttrBuilder
 import com.raquo.domtypes.generic.codecs.BooleanAsTrueFalseStringCodec
 
-/** @tparam A  Attribute, canonically [[com.raquo.domtypes.generic.keys.HtmlAttr]] */
+/**
+  * ARIA is a set of special accessibility attributes which can be added
+  * to any markup, but is especially suited to HTML. The role attribute
+  * defines what the general type of object is (such as an article, alert,
+  * or slider). Additional ARIA attributes provide other useful properties,
+  * such as a description for a form or the current value of a progressbar.
+  *
+  * MDN
+  *
+  * @tparam A Attribute, canonically [[com.raquo.domtypes.generic.keys.HtmlAttr]]
+  */
 trait AriaAttrs[A[_]] { this: HtmlAttrBuilder[A] =>
 
+  // @TODO[API] Provide more specific traits or maybe type-tagged strings for enumerated attributes
+
   /**
-    * ARIA is a set of special accessibility attributes which can be added
-    * to any markup, but is especially suited to HTML. The role attribute
-    * defines what the general type of object is (such as an article, alert,
-    * or slider). Additional ARIA attributes provide other useful properties,
-    * such as a description for a form or the current value of a progressbar.
-    *
-    * MDN
+    * Identifies the currently active descendant of a composite widget.
     */
-  object aria {
+  lazy val activeDescendant: A[String] = stringHtmlAttr("aria-activedescendant")
 
-    // @TODO[API] Provide more specific traits or maybe type-tagged strings for enumerated attributes
+  /**
+    * Indicates whether assistive technologies will present all, or only parts of, the
+    * changed region based on the change notifications defined by the aria-relevant
+    * attribute. See related [[relevant]].
+    */
+  lazy val atomic: A[Boolean] = htmlAttr("aria-atomic", BooleanAsTrueFalseStringCodec)
 
-    /**
-      * Identifies the currently active descendant of a composite widget.
-      */
-    lazy val activeDescendant: A[String] = stringHtmlAttr("aria-activedescendant")
+  /**
+    * Indicates whether user input completion suggestions are provided.
+    *
+    * Enumerated: "inline" | "list" | "both" | "none" (default)
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-autocomplete
+    */
+  lazy val autoComplete: A[String] = stringHtmlAttr("aria-autocomplete")
 
-    /**
-      * Indicates whether assistive technologies will present all, or only parts of, the
-      * changed region based on the change notifications defined by the aria-relevant
-      * attribute. See related [[relevant]].
-      */
-    lazy val atomic: A[Boolean] = htmlAttr("aria-atomic", BooleanAsTrueFalseStringCodec)
+  /**
+    * Indicates whether an element, and its subtree, are currently being updated.
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-busy
+    */
+  lazy val busy: A[Boolean] = htmlAttr("aria-busy", BooleanAsTrueFalseStringCodec)
 
-    /**
-      * Indicates whether user input completion suggestions are provided.
-      *
-      * Enumerated: "inline" | "list" | "both" | "none" (default)
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-autocomplete
-      */
-    lazy val autoComplete: A[String] = stringHtmlAttr("aria-autocomplete")
+  /**
+    * Indicates the current "checked" state of checkboxes, radio buttons, and other
+    * widgets. See related [[pressed]] and [[selected]].
+    *
+    * Enumerated: Tristate – "true" | "false" | "mixed" | undefined (default)
+    * - undefined means the element does not support being checked
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-checked
+    */
+  lazy val checked: A[String] = stringHtmlAttr("aria-checked")
 
-    /**
-      * Indicates whether an element, and its subtree, are currently being updated.
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-busy
-      */
-    lazy val busy: A[Boolean] = htmlAttr("aria-busy", BooleanAsTrueFalseStringCodec)
+  /**
+    * Identifies the element (or elements) whose contents or presence are controlled
+    * by the current element. See related [[owns]].
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-controls
+    */
+  lazy val controls: A[String] = stringHtmlAttr("aria-controls")
 
-    /**
-      * Indicates the current "checked" state of checkboxes, radio buttons, and other
-      * widgets. See related [[pressed]] and [[selected]].
-      *
-      * Enumerated: Tristate – "true" | "false" | "mixed" | undefined (default)
-      * - undefined means the element does not support being checked
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-checked
-      */
-    lazy val checked: A[String] = stringHtmlAttr("aria-checked")
+  /**
+    * Identifies the element (or elements) that describes the object.
+    * See related [[labelledBy]].
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-describedby
+    */
+  lazy val describedBy: A[String] = stringHtmlAttr("aria-describedby")
 
-    /**
-      * Identifies the element (or elements) whose contents or presence are controlled
-      * by the current element. See related [[owns]].
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-controls
-      */
-    lazy val controls: A[String] = stringHtmlAttr("aria-controls")
+  /**
+    * Indicates that the element is perceivable but disabled, so it is not editable
+    * or otherwise operable. See related [[hidden]] and [[readOnly]].
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-disabled
+    */
+  lazy val disabled: A[Boolean] = htmlAttr("aria-disabled", BooleanAsTrueFalseStringCodec)
 
-    /**
-      * Identifies the element (or elements) that describes the object.
-      * See related [[labelledBy]].
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-describedby
-      */
-    lazy val describedBy: A[String] = stringHtmlAttr("aria-describedby")
+  /**
+    * Indicates what functions can be performed when the dragged object is released
+    * on the drop target. This allows assistive technologies to convey the possible
+    * drag options available to users, including whether a pop-up menu of choices is
+    * provided by the application. Typically, drop effect functions can only be
+    * provided once an object has been grabbed for a drag operation as the drop
+    * effect functions available are dependent on the object being dragged.
+    *
+    * Enumerated: "copy" | "move" | "link" | "execute" | "popup" | "none" (default)
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-dropeffect
+    */
+  lazy val dropEffect: A[String] = stringHtmlAttr("aria-dropeffect")
 
-    /**
-      * Indicates that the element is perceivable but disabled, so it is not editable
-      * or otherwise operable. See related [[hidden]] and [[readOnly]].
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-disabled
-      */
-    lazy val disabled: A[Boolean] = htmlAttr("aria-disabled", BooleanAsTrueFalseStringCodec)
+  /**
+    * Indicates whether the element, or another grouping element it controls, is
+    * currently expanded or collapsed.
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-expanded
+    */
+  lazy val expanded: A[Boolean] = htmlAttr("aria-expanded", BooleanAsTrueFalseStringCodec)
 
-    /**
-      * Indicates what functions can be performed when the dragged object is released
-      * on the drop target. This allows assistive technologies to convey the possible
-      * drag options available to users, including whether a pop-up menu of choices is
-      * provided by the application. Typically, drop effect functions can only be
-      * provided once an object has been grabbed for a drag operation as the drop
-      * effect functions available are dependent on the object being dragged.
-      *
-      * Enumerated: "copy" | "move" | "link" | "execute" | "popup" | "none" (default)
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-dropeffect
-      */
-    lazy val dropEffect: A[String] = stringHtmlAttr("aria-dropeffect")
+  /**
+    * Identifies the next element (or elements) in an alternate reading order of
+    * content which, at the user's discretion, allows assistive technology to
+    * override the general default of reading in document source order.
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-flowto
+    */
+  lazy val flowTo: A[String] = stringHtmlAttr("aria-flowto")
 
-    /**
-      * Indicates whether the element, or another grouping element it controls, is
-      * currently expanded or collapsed.
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-expanded
-      */
-    lazy val expanded: A[Boolean] = htmlAttr("aria-expanded", BooleanAsTrueFalseStringCodec)
+  /**
+    * Indicates an element's "grabbed" state in a drag-and-drop operation.
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-grabbed
+    */
+  lazy val grabbed: A[Boolean] = htmlAttr("aria-grabbed", BooleanAsTrueFalseStringCodec)
 
-    /**
-      * Identifies the next element (or elements) in an alternate reading order of
-      * content which, at the user's discretion, allows assistive technology to
-      * override the general default of reading in document source order.
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-flowto
-      */
-    lazy val flowTo: A[String] = stringHtmlAttr("aria-flowto")
+  /**
+    * Indicates that the element has a popup context menu or sub-level menu.
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-haspopup
+    */
+  lazy val hasPopup: A[Boolean] = htmlAttr("aria-haspopup", BooleanAsTrueFalseStringCodec)
 
-    /**
-      * Indicates an element's "grabbed" state in a drag-and-drop operation.
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-grabbed
-      */
-    lazy val grabbed: A[Boolean] = htmlAttr("aria-grabbed", BooleanAsTrueFalseStringCodec)
+  /**
+    * Indicates that the element and all of its descendants are not visible or
+    * perceivable to any user as implemented by the author.
+    * See related [[disabled]].
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-hidden
+    */
+  lazy val hidden: A[Boolean] = htmlAttr("aria-hidden", BooleanAsTrueFalseStringCodec)
 
-    /**
-      * Indicates that the element has a popup context menu or sub-level menu.
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-haspopup
-      */
-    lazy val hasPopup: A[Boolean] = htmlAttr("aria-haspopup", BooleanAsTrueFalseStringCodec)
+  /**
+    * Indicates the entered value does not conform to the format expected by the
+    * application.
+    *
+    * Enumerated: "grammar" | "spelling" | "true" | "false" (default)
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid
+    */
+  lazy val invalid: A[String] = stringHtmlAttr("aria-invalid")
 
-    /**
-      * Indicates that the element and all of its descendants are not visible or
-      * perceivable to any user as implemented by the author.
-      * See related [[disabled]].
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-hidden
-      */
-    lazy val hidden: A[Boolean] = htmlAttr("aria-hidden", BooleanAsTrueFalseStringCodec)
+  /**
+    * Defines a string value that labels the current element.
+    * See related [[labelledBy]].
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-label
+    */
+  lazy val label: A[String] = stringHtmlAttr("aria-label")
 
-    /**
-      * Indicates the entered value does not conform to the format expected by the
-      * application.
-      *
-      * Enumerated: "grammar" | "spelling" | "true" | "false" (default)
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid
-      */
-    lazy val invalid: A[String] = stringHtmlAttr("aria-invalid")
+  /**
+    * Identifies the element (or elements) that labels the current element.
+    * See related [[label]] and [[describedBy]].
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-labelledby
+    */
+  lazy val labelledBy: A[String] = stringHtmlAttr("aria-labelledby")
 
-    /**
-      * Defines a string value that labels the current element.
-      * See related [[labelledBy]].
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-label
-      */
-    lazy val label: A[String] = stringHtmlAttr("aria-label")
+  /**
+    * Defines the hierarchical level of an element within a structure.
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-level
+    */
+  lazy val level: A[Int] = intHtmlAttr("aria-level")
 
-    /**
-      * Identifies the element (or elements) that labels the current element.
-      * See related [[label]] and [[describedBy]].
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-labelledby
-      */
-    lazy val labelledBy: A[String] = stringHtmlAttr("aria-labelledby")
+  /**
+    * Indicates that an element will be updated, and describes the types of updates the
+    * user agents, assistive technologies, and user can expect from the live region.
+    *
+    * Enumerated: "polite" | "assertive" | "off" (default)
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-live
+    */
+  lazy val live: A[String] = stringHtmlAttr("aria-live")
 
-    /**
-      * Defines the hierarchical level of an element within a structure.
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-level
-      */
-    lazy val level: A[Int] = intHtmlAttr("aria-level")
+  /**
+    * Indicates whether a text box accepts multiple lines of input or only a single line.
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-multiline
+    */
+  lazy val multiLine: A[Boolean] = htmlAttr("aria-multiline", BooleanAsTrueFalseStringCodec)
 
-    /**
-      * Indicates that an element will be updated, and describes the types of updates the
-      * user agents, assistive technologies, and user can expect from the live region.
-      *
-      * Enumerated: "polite" | "assertive" | "off" (default)
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-live
-      */
-    lazy val live: A[String] = stringHtmlAttr("aria-live")
+  /**
+    * Indicates that the user may select more than one item from the current selectable descendants.
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-multiselectable
+    */
+  lazy val multiSelectable: A[Boolean] = htmlAttr("aria-multiselectable", BooleanAsTrueFalseStringCodec)
 
-    /**
-      * Indicates whether a text box accepts multiple lines of input or only a single line.
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-multiline
-      */
-    lazy val multiLine: A[Boolean] = htmlAttr("aria-multiline", BooleanAsTrueFalseStringCodec)
+  /**
+    * Indicates whether the element and orientation is horizontal or vertical.
+    *
+    * Enumerated: "vertical" | "horizontal" (default)
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-orientation
+    */
+  lazy val orientation: A[String] = stringHtmlAttr("aria-orientation")
 
-    /**
-      * Indicates that the user may select more than one item from the current selectable descendants.
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-multiselectable
-      */
-    lazy val multiSelectable: A[Boolean] = htmlAttr("aria-multiselectable", BooleanAsTrueFalseStringCodec)
+  /**
+    * Identifies an element (or elements) in order to define a visual, functional, or
+    * contextual parent/child relationship between DOM elements where the DOM hierarchy
+    * cannot be used to represent the relationship. See related [[controls]].
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-owns
+    */
+  lazy val owns: A[String] = stringHtmlAttr("aria-owns")
 
-    /**
-      * Indicates whether the element and orientation is horizontal or vertical.
-      *
-      * Enumerated: "vertical" | "horizontal" (default)
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-orientation
-      */
-    lazy val orientation: A[String] = stringHtmlAttr("aria-orientation")
+  /**
+    * Defines an element's number or position in the current set of listitems or treeitems.
+    * Not required if all elements in the set are present in the DOM. See related [[setSize]].
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-posinset
+    */
+  lazy val posInSet: A[Int] = intHtmlAttr("aria-posinset")
 
-    /**
-      * Identifies an element (or elements) in order to define a visual, functional, or
-      * contextual parent/child relationship between DOM elements where the DOM hierarchy
-      * cannot be used to represent the relationship. See related [[controls]].
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-owns
-      */
-    lazy val owns: A[String] = stringHtmlAttr("aria-owns")
+  /**
+    * Indicates the current "pressed" state of toggle buttons. See related [[checked]] and [[selected]].
+    *
+    * Enumerated: Tristate – "true" | "false" | "mixed" | undefined (default)
+    * - undefined means the element does not support being pressed
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-pressed
+    */
+  lazy val pressed: A[String] = stringHtmlAttr("aria-pressed")
 
-    /**
-      * Defines an element's number or position in the current set of listitems or treeitems.
-      * Not required if all elements in the set are present in the DOM. See related [[setSize]].
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-posinset
-      */
-    lazy val posInSet: A[Int] = intHtmlAttr("aria-posinset")
+  /**
+    * Indicates that the element is not editable, but is otherwise operable. See related [[disabled]].
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-readonly
+    */
+  lazy val readOnly: A[Boolean] = htmlAttr("aria-readonly", BooleanAsTrueFalseStringCodec)
 
-    /**
-      * Indicates the current "pressed" state of toggle buttons. See related [[checked]] and [[selected]].
-      *
-      * Enumerated: Tristate – "true" | "false" | "mixed" | undefined (default)
-      * - undefined means the element does not support being pressed
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-pressed
-      */
-    lazy val pressed: A[String] = stringHtmlAttr("aria-pressed")
+  /**
+    * Indicates what user agent change notifications (additions, removals, etc.)
+    * assistive technologies will receive within a live region. See related [[atomic]].
+    *
+    * Enumerated: "additions" | "removals" | "text" | "all" | "additions text" (default)
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-relevant
+    */
+  lazy val relevant: A[String] = stringHtmlAttr("aria-relevant")
 
-    /**
-      * Indicates that the element is not editable, but is otherwise operable. See related [[disabled]].
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-readonly
-      */
-    lazy val readOnly: A[Boolean] = htmlAttr("aria-readonly", BooleanAsTrueFalseStringCodec)
+  /**
+    * Indicates that user input is required on the element before a form may be submitted.
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-required
+    */
+  lazy val required: A[Boolean] = htmlAttr("aria-required", BooleanAsTrueFalseStringCodec)
 
-    /**
-      * Indicates what user agent change notifications (additions, removals, etc.)
-      * assistive technologies will receive within a live region. See related [[atomic]].
-      *
-      * Enumerated: "additions" | "removals" | "text" | "all" | "additions text" (default)
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-relevant
-      */
-    lazy val relevant: A[String] = stringHtmlAttr("aria-relevant")
+  /**
+    * Indicates the current "selected" state of various widgets.
+    * See related [[checked]] and [[pressed]].
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-selected
+    */
+  lazy val selected: A[Boolean] = htmlAttr("aria-selected", BooleanAsTrueFalseStringCodec)
 
-    /**
-      * Indicates that user input is required on the element before a form may be submitted.
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-required
-      */
-    lazy val required: A[Boolean] = htmlAttr("aria-required", BooleanAsTrueFalseStringCodec)
+  /**
+    * Defines the number of items in the current set of listitems or treeitems.
+    * Not required if all elements in the set are present in the DOM.
+    * See related [[posInSet]].
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-setsize
+    */
+  lazy val setSize: A[Int] = intHtmlAttr("aria-setsize")
 
-    /**
-      * Indicates the current "selected" state of various widgets.
-      * See related [[checked]] and [[pressed]].
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-selected
-      */
-    lazy val selected: A[Boolean] = htmlAttr("aria-selected", BooleanAsTrueFalseStringCodec)
+  /**
+    * Indicates if items in a table or grid are sorted in ascending or descending order.
+    *
+    * Enumerated: "ascending" | "descending" | "other" | "none" (default)
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-sort
+    */
+  lazy val sort: A[String] = stringHtmlAttr("aria-sort")
 
-    /**
-      * Defines the number of items in the current set of listitems or treeitems.
-      * Not required if all elements in the set are present in the DOM.
-      * See related [[posInSet]].
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-setsize
-      */
-    lazy val setSize: A[Int] = intHtmlAttr("aria-setsize")
+  /**
+    * Defines the maximum allowed value for a range widget.
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-valuemax
+    */
+  lazy val valueMax: A[Double] = doubleHtmlAttr("aria-valuemax")
 
-    /**
-      * Indicates if items in a table or grid are sorted in ascending or descending order.
-      *
-      * Enumerated: "ascending" | "descending" | "other" | "none" (default)
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-sort
-      */
-    lazy val sort: A[String] = stringHtmlAttr("aria-sort")
+  /**
+    * Defines the minimum allowed value for a range widget.
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-valuemin
+    */
+  lazy val valueMin: A[Double] = doubleHtmlAttr("aria-valuemin")
 
-    /**
-      * Defines the maximum allowed value for a range widget.
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-valuemax
-      */
-    lazy val valueMax: A[Double] = doubleHtmlAttr("aria-valuemax")
+  /**
+    * Defines the current value for a range widget. See related [[valueText]].
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-valuenow
+    */
+  lazy val valueNow: A[Double] = doubleHtmlAttr("aria-valuenow")
 
-    /**
-      * Defines the minimum allowed value for a range widget.
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-valuemin
-      */
-    lazy val valueMin: A[Double] = doubleHtmlAttr("aria-valuemin")
-
-    /**
-      * Defines the current value for a range widget. See related [[valueText]].
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-valuenow
-      */
-    lazy val valueNow: A[Double] = doubleHtmlAttr("aria-valuenow")
-
-    /**
-      * Defines the human readable text alternative of aria-valuenow for a range widget.
-      *
-      * https://www.w3.org/TR/wai-aria/states_and_properties#aria-valuetext
-      */
-    lazy val valueText: A[String] = stringHtmlAttr("aria-valuetext")
-  }
+  /**
+    * Defines the human readable text alternative of aria-valuenow for a range widget.
+    *
+    * https://www.w3.org/TR/wai-aria/states_and_properties#aria-valuetext
+    */
+  lazy val valueText: A[String] = stringHtmlAttr("aria-valuetext")
 }

--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/attrs/HtmlAttrs.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/attrs/HtmlAttrs.scala
@@ -31,28 +31,6 @@ trait HtmlAttrs[A[_]] { this: HtmlAttrBuilder[A] =>
   lazy val contextMenuId: A[String] = stringHtmlAttr("contextmenu")
 
   /**
-    * This class of attributes, called custom data attributes, allows proprietary
-    * information to be exchanged between the HTML and its DOM representation that
-    * may be used by scripts. All such custom data are available via the HTMLElement
-    * interface of the element the attribute is set on. The HTMLElement.dataset
-    * property gives access to them.
-    *
-    * The `suffix` is subject to the following restrictions:
-    *
-    * must not start with xml, whatever case is used for these letters;
-    * must not contain any semicolon (U+003A);
-    * must not contain capital A to Z letters.
-    *
-    * Note that the HTMLElement.dataset attribute is a StringMap and the name of the
-    * custom data attribute data-test-value will be accessible via
-    * HTMLElement.dataset.testValue as any dash (U+002D) is replaced by the capitalization
-    * of the next letter (camelcase).
-    *
-    * MDN
-    */
-  def dataAttr(suffix: String): A[String] = stringHtmlAttr(s"data-$suffix")
-
-  /**
     * Specifies whether the dragged data is copied, moved, or linked, when dropped
     * Acceptable values: `copy` | `move` | `link`
     */
@@ -106,16 +84,6 @@ trait HtmlAttrs[A[_]] { this: HtmlAttrBuilder[A] =>
     * types: number, range, date, datetime, datetime-local, month, time and week.
     */
   lazy val step: A[String] = stringHtmlAttr("step")
-
-  /**
-    * This attribute contains CSS styling declarations to be applied to the
-    * element. Note that it is recommended for styles to be defined in a separate
-    * file or files. This attribute and the style element have mainly the
-    * purpose of allowing for quick styling, for example for testing purposes.
-    *
-    * MDN
-    */
-  lazy val styleAttr: A[String] = stringHtmlAttr("style")
 
   /**
     * This attribute is used to define the type of the content linked to. The

--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/attrs/SvgAttrs.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/attrs/SvgAttrs.scala
@@ -184,25 +184,6 @@ trait SvgAttrs[A[_]] { this: SvgAttrBuilder[A] =>
 
 
   /**
-    * Assigns a class name or set of class names to an element. You may assign the same
-    * class name or names to any number of elements. If you specify multiple class names,
-    * they must be separated by whitespace characters.
-    * The class name of an element has two key roles:
-    * -As a style sheet selector, for use when an author wants to assign style
-    * information to a set of elements.
-    * -For general usage by the browser.
-    * The class can be used to style SVG content using CSS.
-    *
-    * Value 	<list-of-class-names>
-    *
-    * MDN
-    */
-  lazy val className: A[String] = stringSvgAttr("class")
-
-  lazy val cls: A[String] = className
-
-
-  /**
     * The clip attribute has the same parameter values as defined for the css clip property.
     * Unitless values, which indicate current user coordinates, are permitted on the coordinate
     * values on the <shape>. The value of auto defines a clipping path along the bounds of

--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/complex/ComplexHtmlKeys.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/complex/ComplexHtmlKeys.scala
@@ -1,0 +1,76 @@
+package com.raquo.domtypes.generic.defs.complex
+
+/** This trait gives you a very flexible way to define HTML keys that
+  * consuming libraries often have strong opinions about.
+  *
+  * Use [[canonical.CanonicalComplexHtmlKeys]] if you lack such strong opinions.
+  *
+  * If your opinions are too strong to use this trait – don't! You can implement
+  * any subset of these keys yourself with whatever names you like.
+  */
+trait ComplexHtmlKeys[ClassNameRA, ClsRA, RelRA, DataA, StyleA, TextContentP] {
+
+  /**
+    * This attribute is a space-separated list of the classes of the element.
+    * Classes allows CSS and Javascript to select and access specific elements
+    * via the class selectors or functions like the DOM method
+    * document.getElementsByClassName.
+    *
+    * MDN
+    */
+  def className: ClassNameRA
+
+  def cls: ClsRA
+
+  /**
+    * This attribute names a relationship of the linked document to the current
+    * document. The attribute must be a space-separated list of the link types
+    * values. The most common use of this attribute is to specify a link to an
+    * external style sheet: the rel attribute is set to stylesheet, and the href
+    * attribute is set to the URL of an external style sheet to format the page.
+    *
+    *
+    * MDN
+    */
+  def rel: RelRA
+
+  /**
+    * This class of attributes, called custom data attributes, allows proprietary
+    * information to be exchanged between the HTML and its DOM representation that
+    * may be used by scripts. All such custom data are available via the HTMLElement
+    * interface of the element the attribute is set on. The HTMLElement.dataset
+    * property gives access to them.
+    *
+    * The `suffix` is subject to the following restrictions:
+    *
+    * must not start with xml, whatever case is used for these letters;
+    * must not contain any semicolon (U+003A);
+    * must not contain capital A to Z letters.
+    *
+    * Note that the HTMLElement.dataset attribute is a StringMap and the name of the
+    * custom data attribute data-test-value will be accessible via
+    * HTMLElement.dataset.testValue as any dash (U+002D) is replaced by the capitalization
+    * of the next letter (camelcase).
+    *
+    * MDN
+    */
+  def dataAttr(suffix: String): DataA
+
+  /**
+    * This attribute contains CSS styling declarations to be applied to the
+    * element. Note that it is recommended for styles to be defined in a separate
+    * file or files. This attribute and the style element have mainly the
+    * purpose of allowing for quick styling, for example for testing purposes.
+    *
+    * MDN
+    */
+  def styleAttr: StyleA
+
+  /** Determines the textual content of an element and all its descendants.
+    * Setting this property replaces all of the node's children with a text node containing
+    * the provided string.
+    *
+    * MDN
+    */
+  def textContent: TextContentP
+}

--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/complex/ComplexHtmlKeys.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/complex/ComplexHtmlKeys.scala
@@ -8,7 +8,7 @@ package com.raquo.domtypes.generic.defs.complex
   * If your opinions are too strong to use this trait – don't! You can implement
   * any subset of these keys yourself with whatever names you like.
   */
-trait ComplexHtmlKeys[ClassNameRA, ClsRA, RelRA, DataA, StyleA, TextContentP] {
+trait ComplexHtmlKeys[ClassNameRA, RelRA, RoleRA, DataA, StyleA, TextContentP] {
 
   /**
     * This attribute is a space-separated list of the classes of the element.
@@ -20,7 +20,8 @@ trait ComplexHtmlKeys[ClassNameRA, ClsRA, RelRA, DataA, StyleA, TextContentP] {
     */
   def className: ClassNameRA
 
-  def cls: ClsRA
+  // @TODO[Performance] Wouldn't `@inline def` be better for aliasing in Scala.js? className will be overriden with a lazy val anyway.
+  lazy val cls: ClassNameRA = className
 
   /**
     * This attribute names a relationship of the linked document to the current
@@ -33,6 +34,23 @@ trait ComplexHtmlKeys[ClassNameRA, ClsRA, RelRA, DataA, StyleA, TextContentP] {
     * MDN
     */
   def rel: RelRA
+
+  /**
+    * The attribute describes the role(s) the current element plays in the
+    * context of the document. This can be used, for example,
+    * by applications and assistive technologies to determine the purpose of
+    * an element. This could allow a user to make informed decisions on which
+    * actions may be taken on an element and activate the selected action in a
+    * device independent way. It could also be used as a mechanism for
+    * annotating portions of a document in a domain specific way (e.g.,
+    * a legal term taxonomy). Although the role attribute may be used to add
+    * semantics to an element, authors should use elements with inherent
+    * semantics, such as p, rather than layering semantics on semantically
+    * neutral elements, such as div role="paragraph".
+    *
+    * See: [[http://www.w3.org/TR/role-attribute/#s_role_module_attributes]]
+    */
+  def role: RoleRA
 
   /**
     * This class of attributes, called custom data attributes, allows proprietary
@@ -65,12 +83,4 @@ trait ComplexHtmlKeys[ClassNameRA, ClsRA, RelRA, DataA, StyleA, TextContentP] {
     * MDN
     */
   def styleAttr: StyleA
-
-  /** Determines the textual content of an element and all its descendants.
-    * Setting this property replaces all of the node's children with a text node containing
-    * the provided string.
-    *
-    * MDN
-    */
-  def textContent: TextContentP
 }

--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/complex/ComplexSvgKeys.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/complex/ComplexSvgKeys.scala
@@ -8,7 +8,7 @@ package com.raquo.domtypes.generic.defs.complex
   * If your opinions are too strong to use this trait – don't! You can implement
   * any subset of these keys yourself with whatever names you like.
   */
-trait ComplexSvgKeys[ClassNameA, ClsA] {
+trait ComplexSvgKeys[ClassNameA] {
 
   /**
     * Assigns a class name or set of class names to an element. You may assign the same
@@ -26,5 +26,5 @@ trait ComplexSvgKeys[ClassNameA, ClsA] {
     */
   def className: ClassNameA
 
-  def cls: ClsA
+  lazy val cls: ClassNameA = className
 }

--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/complex/ComplexSvgKeys.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/complex/ComplexSvgKeys.scala
@@ -1,0 +1,30 @@
+package com.raquo.domtypes.generic.defs.complex
+
+/** This trait gives you a very flexible way to define SVG keys that
+  * consuming libraries often have strong opinions about.
+  *
+  * Use [[canonical.CanonicalComplexHtmlKeys]] if you lack such strong opinions.
+  *
+  * If your opinions are too strong to use this trait – don't! You can implement
+  * any subset of these keys yourself with whatever names you like.
+  */
+trait ComplexSvgKeys[ClassNameA, ClsA] {
+
+  /**
+    * Assigns a class name or set of class names to an element. You may assign the same
+    * class name or names to any number of elements. If you specify multiple class names,
+    * they must be separated by whitespace characters.
+    * The class name of an element has two key roles:
+    * -As a style sheet selector, for use when an author wants to assign style
+    * information to a set of elements.
+    * -For general usage by the browser.
+    * The class can be used to style SVG content using CSS.
+    *
+    * Value 	<list-of-class-names>
+    *
+    * MDN
+    */
+  def className: ClassNameA
+
+  def cls: ClsA
+}

--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/complex/canonical/CanonicalComplexHtmlKeys.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/complex/canonical/CanonicalComplexHtmlKeys.scala
@@ -14,14 +14,11 @@ trait CanonicalComplexHtmlKeys[RA[_, _], A[_], P[_, _]] extends ComplexHtmlKeys[
 
   override lazy val className: RA[String, String] = stringReflectedAttr(attrKey = "class", propKey = "className")
 
-  override lazy val cls: RA[String, String] = className
-
   override lazy val rel: RA[String, String] = stringReflectedAttr("rel")
+
+  override lazy val role: RA[String, String] = stringReflectedAttr("role")
 
   override def dataAttr(suffix: String): A[String] = stringHtmlAttr(s"data-$suffix")
 
   override lazy val styleAttr: A[String] = stringHtmlAttr("style")
-
-  override lazy val textContent: P[String, String] = stringProp("textContent")
-
 }

--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/complex/canonical/CanonicalComplexHtmlKeys.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/complex/canonical/CanonicalComplexHtmlKeys.scala
@@ -1,0 +1,27 @@
+package com.raquo.domtypes.generic.defs.complex.canonical
+
+import com.raquo.domtypes.generic.builders.{HtmlAttrBuilder, PropBuilder, ReflectedHtmlAttrBuilder}
+import com.raquo.domtypes.generic.defs.complex.ComplexHtmlKeys
+
+trait CanonicalComplexHtmlKeys[RA[_, _], A[_], P[_, _]] extends ComplexHtmlKeys[
+  RA[String, String],
+  RA[String, String],
+  RA[String, String],
+  A[String],
+  A[String],
+  P[String, String]
+] { this: ReflectedHtmlAttrBuilder[RA] with HtmlAttrBuilder[A] with PropBuilder[P] =>
+
+  override lazy val className: RA[String, String] = stringReflectedAttr(attrKey = "class", propKey = "className")
+
+  override lazy val cls: RA[String, String] = className
+
+  override lazy val rel: RA[String, String] = stringReflectedAttr("rel")
+
+  override def dataAttr(suffix: String): A[String] = stringHtmlAttr(s"data-$suffix")
+
+  override lazy val styleAttr: A[String] = stringHtmlAttr("style")
+
+  override lazy val textContent: P[String, String] = stringProp("textContent")
+
+}

--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/complex/canonical/CanonicalComplexSvgKeys.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/complex/canonical/CanonicalComplexSvgKeys.scala
@@ -1,0 +1,11 @@
+package com.raquo.domtypes.generic.defs.complex.canonical
+
+import com.raquo.domtypes.generic.builders.SvgAttrBuilder
+import com.raquo.domtypes.generic.defs.complex.ComplexSvgKeys
+
+trait CanonicalComplexSvgKeys[A[_]] extends ComplexSvgKeys[A[String], A[String]] { this: SvgAttrBuilder[A] =>
+
+  override lazy val className: A[String] = stringSvgAttr("class")
+
+  override lazy val cls: A[String] = className
+}

--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/complex/canonical/CanonicalComplexSvgKeys.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/complex/canonical/CanonicalComplexSvgKeys.scala
@@ -3,9 +3,7 @@ package com.raquo.domtypes.generic.defs.complex.canonical
 import com.raquo.domtypes.generic.builders.SvgAttrBuilder
 import com.raquo.domtypes.generic.defs.complex.ComplexSvgKeys
 
-trait CanonicalComplexSvgKeys[A[_]] extends ComplexSvgKeys[A[String], A[String]] { this: SvgAttrBuilder[A] =>
+trait CanonicalComplexSvgKeys[A[_]] extends ComplexSvgKeys[A[String]] { this: SvgAttrBuilder[A] =>
 
   override lazy val className: A[String] = stringSvgAttr("class")
-
-  override lazy val cls: A[String] = className
 }

--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/props/Props.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/props/Props.scala
@@ -23,14 +23,6 @@ trait Props[P[_, _]] { this: PropBuilder[P] =>
     */
   lazy val checked: P[Boolean, Boolean] = prop("checked", BooleanAsIsCodec)
 
-  /** Determines the textual content of an element and all its descendants.
-    * Setting this property replaces all of the node's children with a text node containing
-    * the provided string.
-    *
-    * MDN
-    */
-  lazy val textContent: P[String, String] = stringProp("textContent")
-
   /**
     * Indicates whether an <option> element is _currently_ selected. This is different from `selected` _attribute_,
     * which contains the _initial_ selected status of the element.

--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/reflectedAttrs/ReflectedHtmlAttrs.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/reflectedAttrs/ReflectedHtmlAttrs.scala
@@ -451,23 +451,6 @@ trait ReflectedHtmlAttrs[RA[_, _]] { this: ReflectedHtmlAttrBuilder[RA] =>
   lazy val required: RA[Boolean, Boolean] = booleanReflectedAttr("required", attrCodec = BooleanAsAttrPresenceCodec)
 
   /**
-    * The attribute describes the role(s) the current element plays in the
-    * context of the document. This can be used, for example,
-    * by applications and assistive technologies to determine the purpose of
-    * an element. This could allow a user to make informed decisions on which
-    * actions may be taken on an element and activate the selected action in a
-    * device independent way. It could also be used as a mechanism for
-    * annotating portions of a document in a domain specific way (e.g.,
-    * a legal term taxonomy). Although the role attribute may be used to add
-    * semantics to an element, authors should use elements with inherent
-    * semantics, such as p, rather than layering semantics on semantically
-    * neutral elements, such as div role="paragraph".
-    *
-    * See: [[http://www.w3.org/TR/role-attribute/#s_role_module_attributes]]
-    */
-  lazy val role: RA[String, String] = stringReflectedAttr("role")
-
-  /**
     * The number of visible text lines for a text control.
     *
     * MDN

--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/reflectedAttrs/ReflectedHtmlAttrs.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/reflectedAttrs/ReflectedHtmlAttrs.scala
@@ -1,7 +1,7 @@
 package com.raquo.domtypes.generic.defs.reflectedAttrs
 
 import com.raquo.domtypes.generic.builders.ReflectedHtmlAttrBuilder
-import com.raquo.domtypes.generic.codecs.{BooleanAsAttrPresenceCodec, BooleanAsTrueFalseStringCodec, BooleanAsYesNoStringCodec, IterableAsSpaceSeparatedStringCodec}
+import com.raquo.domtypes.generic.codecs.{BooleanAsAttrPresenceCodec, BooleanAsTrueFalseStringCodec, BooleanAsYesNoStringCodec}
 
 /**
   * Reflected attributes are attributes that can be set using either a DOM property
@@ -91,26 +91,6 @@ trait ReflectedHtmlAttrs[RA[_, _]] { this: ReflectedHtmlAttrBuilder[RA] =>
     * MDN
     */
   lazy val autoFocus: RA[Boolean, Boolean] = booleanReflectedAttr("autofocus", attrCodec = BooleanAsAttrPresenceCodec)
-
-  /** This attribute converts [[className]] into an iterable of class names */
-  lazy val classNames: RA[Iterable[String], String] = reflectedAttr(
-    attrKey = "class",
-    propKey = "className",
-    attrCodec = IterableAsSpaceSeparatedStringCodec,
-    propCodec = IterableAsSpaceSeparatedStringCodec
-  )
-
-  /**
-    * This attribute is a space-separated list of the classes of the element.
-    * Classes allows CSS and Javascript to select and access specific elements
-    * via the class selectors or functions like the DOM method
-    * document.getElementsByClassName.
-    *
-    * MDN
-    */
-  lazy val className: RA[String, String] = stringReflectedAttr(attrKey = "class", propKey = "className")
-
-  lazy val cls: RA[String, String] = className
 
   /**
     * The visible width of text input or <textArea>, in average character widths.
@@ -459,18 +439,6 @@ trait ReflectedHtmlAttrs[RA[_, _]] { this: ReflectedHtmlAttrBuilder[RA] =>
     propKey = "readOnly",
     attrCodec = BooleanAsAttrPresenceCodec
   )
-
-  /**
-    * This attribute names a relationship of the linked document to the current
-    * document. The attribute must be a space-separated list of the link types
-    * values. The most common use of this attribute is to specify a link to an
-    * external style sheet: the rel attribute is set to stylesheet, and the href
-    * attribute is set to the URL of an external style sheet to format the page.
-    *
-    *
-    * MDN
-    */
-  lazy val rel: RA[String, String] = stringReflectedAttr("rel")
 
   /**
     * This attribute specifies that the user must fill in a value before


### PR DESCRIPTION
This PR provides a way for consuming libraries to define custom interfaces for some composite or otherwise special keys.

The attributes I chose are: `cls`, `className`, `rel`, `dataAttr`, `styleAttr`, `textContent`.

I was thinking of also adding `role` attribute to the list – it's also a composite attribute (space-separated strings), but I've never used it and I'm not sure what kind of usage patterns it has. Does it even make sense to have special APIs for it...

Fixes #32.

# TODO
- [x] Change v0.9 date from Aug to Sep