### PR TITLE
Change the span tag to be a lazy val.

### DIFF
--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/tags/TextTags.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/tags/TextTags.scala
@@ -97,7 +97,7 @@ trait TextTags[T[_ <: DomHtmlElement], DomHtmlElement, HtmlAnchor <: DomHtmlElem
     *
     *  MDN  [[org.scalajs.dom.html.Span]]
     */
-  def span: T[HtmlSpan] = htmlTag("span")
+  lazy val span: T[HtmlSpan] = htmlTag("span")
 
   /**
     * Represents a line break.


### PR DESCRIPTION
Unless this is intended, shouldn't `span` be a lazy val too?