### PR TITLE
Fix: `fontSizeAdjust`, `listStyleImage.none` should be `lazy val`s, not `def`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The following allowances for breaking changes exist _for now_:
 
 TODO: Adopt more mature versioning, eventually. Read about eviction, binary compatibility, etc.
 
+#### v0.8.1 – Sep 2018
+
+* **Fix: `span`, `fontSizeAdjust`, `listStyleImage.none` should be `lazy val`s, not `def`s**
+
 #### v0.8 – Aug 2018
 
 * **New: Add `namespace` param to `SvgAttr`**

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 _Scala DOM Types_ provides listings and type definitions for Javascript HTML and SVG tags as well as their attributes, DOM properties, and CSS styles.
 
-    "com.raquo" %%% "domtypes" % "0.8"    // scala.js
-    "com.raquo" %% "domtypes" % "0.8"     // JVM
+    "com.raquo" %%% "domtypes" % "0.8.1"    // scala.js
+    "com.raquo" %% "domtypes" % "0.8.1"     // JVM
 
 Our type definitions are designed for easy integration into any kind of library. You can use this project to build your own DOM libraries like React or Snabbdom, but type-safe. For example, popular Scala.js reactive UI library [Outwatch](https://github.com/OutWatch/outwatch/) recently switched to _Scala DOM Types_, offloading thousands of lines of code and improving type safety ([diff](https://github.com/OutWatch/outwatch/pull/62)). I am also using _Scala DOM Types_ in my own projects:
 

--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/styles/Styles.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/styles/Styles.scala
@@ -1061,7 +1061,7 @@ trait Styles[StyleSetter] extends StylesMisc[StyleSetter] { this: StyleBuilders[
     */
   object listStyleImage extends Style[String]("listStyleImage", "list-style-image") {
 
-    def none: StyleSetter = buildStringStyleSetter(this, "none")
+    lazy val none: StyleSetter = buildStringStyleSetter(this, "none")
   }
 
 
@@ -1679,7 +1679,7 @@ trait Styles[StyleSetter] extends StylesMisc[StyleSetter] { this: StyleBuilders[
     *
     * MDN
     */
-  def fontSizeAdjust: Style[Double] = style("fontSizeAdjust", "font-size-adjust")
+  lazy val fontSizeAdjust: Style[Double] = style("fontSizeAdjust", "font-size-adjust")
 
   /**
     * The font-family CSS property allows for a prioritized list of font family


### PR DESCRIPTION
In continuation of #44. I will release this as v0.8.1 shortly. Technically it's breaking compatibility a bit, but given the nature of this bug fix, realistically I don't think anyone will be negatively affected.