### PR TITLE
PointerEventProps

### DIFF
--- a/js/src/main/scala/com/raquo/domtypes/jsdom/defs/events/TypedTargetPointerEvent.scala
+++ b/js/src/main/scala/com/raquo/domtypes/jsdom/defs/events/TypedTargetPointerEvent.scala
@@ -1,0 +1,10 @@
+package com.raquo.domtypes.jsdom.defs.events
+
+import org.scalajs.dom
+
+import scala.scalajs.js
+
+@js.native
+trait TypedTargetPointerEvent[+T <: dom.EventTarget]
+  extends dom.PointerEvent
+  with TypedTargetEvent[T]

--- a/js/src/main/scala/com/raquo/domtypes/jsdom/defs/package.scala
+++ b/js/src/main/scala/com/raquo/domtypes/jsdom/defs/package.scala
@@ -41,7 +41,7 @@ package object defs {
       EP,
       dom.Event,
       dom.PointerEvent,
-      TypedTargetPointerEvent[dom.Element],
+      TypedTargetPointerEvent[dom.Element]
     ]
 
     type WindowOnlyEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.WindowOnlyEventProps[

--- a/js/src/main/scala/com/raquo/domtypes/jsdom/defs/package.scala
+++ b/js/src/main/scala/com/raquo/domtypes/jsdom/defs/package.scala
@@ -1,7 +1,7 @@
 package com.raquo.domtypes.jsdom
 
 import com.raquo.domtypes.generic
-import com.raquo.domtypes.jsdom.defs.events.{PageTransitionEvent, TypedTargetEvent, TypedTargetFocusEvent, TypedTargetMouseEvent}
+import com.raquo.domtypes.jsdom.defs.events._
 import org.scalajs.dom
 
 package object defs {
@@ -35,6 +35,13 @@ package object defs {
       dom.MouseEvent,
       TypedTargetMouseEvent[dom.Element],
       dom.DragEvent
+    ]
+
+    type PointerEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.PointerEventProps[
+      EP,
+      dom.Event,
+      dom.PointerEvent,
+      TypedTargetPointerEvent[dom.Element],
     ]
 
     type WindowOnlyEventProps[EP[_ <: dom.Event]] = generic.defs.eventProps.WindowOnlyEventProps[

--- a/js/src/main/scala/com/raquo/domtypes/jsdom/defs/package.scala
+++ b/js/src/main/scala/com/raquo/domtypes/jsdom/defs/package.scala
@@ -70,7 +70,8 @@ package object defs {
       with KeyboardEventProps[EP]
       with MediaEventProps[EP]
       with MiscellaneousEventProps[EP]
-      with MouseEventProps[EP] { this: generic.builders.EventPropBuilder[EP, dom.Event] => }
+      with MouseEventProps[EP]
+      with PointerEventProps[EP] { this: generic.builders.EventPropBuilder[EP, dom.Event] => }
 
     /** Matches WindowEventHandlers: https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers */
     trait WindowEventProps[EP[_ <: dom.Event]]

--- a/js/src/test/scala/com/raquo/domtypes/CompileTest.scala
+++ b/js/src/test/scala/com/raquo/domtypes/CompileTest.scala
@@ -9,7 +9,7 @@ import com.raquo.domtypes.generic.defs.props.Props
 import com.raquo.domtypes.generic.defs.reflectedAttrs.ReflectedHtmlAttrs
 import com.raquo.domtypes.generic.defs.styles.{Styles, Styles2}
 import com.raquo.domtypes.generic.keys.{EventProp, HtmlAttr, Prop, Style, SvgAttr}
-import com.raquo.domtypes.jsdom.defs.eventProps.{ClipboardEventProps, DocumentOnlyEventProps, ErrorEventProps, FormEventProps, HTMLElementEventProps, KeyboardEventProps, MediaEventProps, MiscellaneousEventProps, MouseEventProps, WindowOnlyEventProps}
+import com.raquo.domtypes.jsdom.defs.eventProps.{ClipboardEventProps, DocumentOnlyEventProps, ErrorEventProps, FormEventProps, HTMLElementEventProps, KeyboardEventProps, MediaEventProps, MiscellaneousEventProps, MouseEventProps, PointerEventProps, WindowOnlyEventProps}
 import com.raquo.domtypes.jsdom.defs.tags.{DocumentTags, EmbedTags, FormTags, GroupingTags, MiscTags, SectionTags, SvgTags, TableTags, TextTags}
 import org.scalajs.dom
 
@@ -46,6 +46,7 @@ class CompileTest {
     with MediaEventProps[EventProp]
     with MiscellaneousEventProps[EventProp]
     with MouseEventProps[EventProp]
+    with PointerEventProps[EventProp]
     with DocumentOnlyEventProps[EventProp]
     with WindowOnlyEventProps[EventProp]
     // Props

--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/eventProps/PointerEventProps.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/eventProps/PointerEventProps.scala
@@ -1,0 +1,115 @@
+package com.raquo.domtypes.generic.defs.eventProps
+
+import com.raquo.domtypes.generic.builders.EventPropBuilder
+
+/**
+ * Most of today's web content assumes the user's pointing device will be a mouse.
+ * However, since many devices support other types of pointing input devices,
+ * such as pen/stylus and touch surfaces, extensions to the existing pointing device event models
+ * are needed and pointer events address that need.
+ *
+ * Pointer events are DOM events that are fired for a pointing device.
+ * They are designed to create a single DOM event model to handle pointing input devices such as a mouse,
+ * pen/stylus or touch (such as one or more fingers).
+ * The pointer is a hardware-agnostic device that can target a specific set of screen coordinates.
+ * Having a single event model for pointers can simplify creating Web sites and applications
+ * and provide a good user experience regardless of the user's hardware.
+ * However, for scenarios when device-specific handling is desired,
+ * pointer events defines a property to inspect the device type which produced the event.
+ *
+ * The events needed to handle generic pointer input are analogous to mouse events
+ * (mousedown/pointerdown, mousemove/pointermove, etc.).
+ * Consequently, pointer event types are intentionally similar to mouse event types.
+ * Additionally, a pointer event contains the usual properties present in mouse events
+ * (client coordinates, target element, button states, etc.)
+ * in addition to new properties for other forms of input: pressure, contact geometry, tilt, etc.
+ * In fact, the PointerEvent interface inherits all of the MouseEvent's properties thus facilitating
+ * migrating content from mouse events to pointer events.
+ *
+ * MDN
+ */
+trait PointerEventProps[
+  EP[_ <: DomEvent],
+  DomEvent,
+  DomPointerEvent <: DomEvent,
+  DomElementPointerEvent <: DomPointerEvent
+] { this: EventPropBuilder[EP, DomEvent] =>
+
+  /**
+   * fired when a pointing device is moved into an element's hit test boundaries.
+   *
+   * MDN
+   */
+  lazy val onPointerOver: EP[DomElementPointerEvent] = eventProp("pointerover")
+
+  /**
+   * fired when a pointing device is moved into the hit test boundaries of an element
+   * or one of its descendants, including as a result of a pointerdown event
+   * from a device that does not support hover (see pointerdown).
+   *
+   * MDN
+   */
+  lazy val onPointerEnter: EP[DomElementPointerEvent] = eventProp("pointerenter")
+
+  /**
+   * fired when a pointer becomes active.
+   *
+   * MDN
+   */
+  lazy val onPointerDown: EP[DomElementPointerEvent] = eventProp("pointerdown")
+
+  /**
+   * fired when a pointer changes coordinates.
+   *
+   * MDN
+   */
+  lazy val onPointerMove: EP[DomElementPointerEvent] = eventProp("pointermove")
+
+  /**
+   * fired when a pointer is no longer active.
+   *
+   * MDN
+   */
+  lazy val onPointerUp: EP[DomElementPointerEvent] = eventProp("pointerup")
+
+  /**
+   * a browser fires this event if it concludes the pointer will no longer be able
+   * to generate events (for example the related device is deactived).
+   *
+   * MDN
+   */
+  lazy val onPointerCancel: EP[DomElementPointerEvent] = eventProp("pointercancel")
+
+  /**
+   * fired for several reasons including: pointing device is moved out of
+   * the hit test boundaries of an element;
+   * firing the pointerup event for a device that does not support hover (see pointerup);
+   * after firing the pointercancel event (see pointercancel);
+   * when a pen stylus leaves the hover range detectable by the digitizer.
+   *
+   * MDN
+   */
+  lazy val onPointerOut: EP[DomElementPointerEvent] = eventProp("pointerout")
+
+  /**
+   * fired when a pointing device is moved out of the hit test boundaries of an element.
+   * For pen devices, this event is fired when the stylus leaves the hover range detectable by the digitizer.
+   *
+   * MDN
+   */
+  lazy val onPointerLeave: EP[DomElementPointerEvent] = eventProp("pointerleave")
+
+  /**
+   * fired when an element receives pointer capture.
+   *
+   * MDN
+   */
+  lazy val gotPointerCapture: EP[DomElementPointerEvent] = eventProp("gotpointercapture")
+
+  /**
+   * Fired after pointer capture is released for a pointer.
+   *
+   * MDN
+   */
+  lazy val lostPointerCapture: EP[DomElementPointerEvent] = eventProp("lostpointercapture")
+}


### PR DESCRIPTION
Pointer events are now available [across all major browsers](https://caniuse.com/#feat=pointer-events), since they provide [several advantages](https://developers.google.com/web/updates/2016/10/pointer-events) over traditional mouse and touch events, it would be handy to be able to use them in scala-dom-types.