### PR TITLE
Fix: svg attribute typo: 'mak' -> 'mask'

### DIFF
--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/attrs/SvgAttrs.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/attrs/SvgAttrs.scala
@@ -838,7 +838,7 @@ trait SvgAttrs[A[_]] { this: SvgAttrBuilder[A] =>
     *
     * MDN
     */
-  lazy val maskAttr: A[String] = stringSvgAttr("mak")
+  lazy val maskAttr: A[String] = stringSvgAttr("mask")
 
 
   /**


### PR DESCRIPTION
as titled