### PR TITLE
Build: Use github URL instead of local path in SJSIR files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,15 @@ lazy val domtypes = crossProject(JSPlatform, JVMPlatform).in(file("."))
     scalaJSLinkerConfig ~= { _.withSourceMap(false) },
     libraryDependencies ++= Seq(
       ("org.scala-js" %%% "scalajs-dom" % Versions.ScalaJsDom).withDottyCompat(scalaVersion.value)
-    )
+    ),
+    scalacOptions ++= {
+      val remote = s"https://raw.githubusercontent.com/raquo/scala-dom-types/${git.gitHeadCommit.value.get}"
+
+      Seq(
+        s"-P:scalajs:mapSourceURI:${file("js").toURI}->$remote/js/",
+        s"-P:scalajs:mapSourceURI:${file("shared").toURI}->$remote/shared/"
+      )
+    }
   )
 
 lazy val domtypesJS = domtypes.js

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,3 +13,5 @@ addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.16")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")


### PR DESCRIPTION
Maps local file paths to persistent Github URLs in compiled artifacts.

See raquo/Laminar#91 for discussion and more details.

Note here the mappings are slightly different from Airstream and Laminar since the `src` directories aren't at the project root. I spot checked SJSIR files for files corresponding to both `shared` and `js` source files and got valid github URLS for both.