### PR TITLE
Integrate with `InputEvent`

### DIFF
--- a/js/src/main/scala/com/raquo/domtypes/jsdom/defs/package.scala
+++ b/js/src/main/scala/com/raquo/domtypes/jsdom/defs/package.scala
@@ -16,7 +16,7 @@ package object defs {
       EP,
       dom.Event,
       TypedTargetFocusEvent[dom.Element],
-      dom.Event,
+      dom.InputEvent,
       TypedTargetEvent[dom.Element],
       TypedTargetEvent[dom.html.Element],
       TypedTargetEvent[dom.html.Form],

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -8,5 +8,5 @@ object Versions {
 
   val Scala_3 = "3.2.0"
 
-  val ScalaJsDom = "2.1.0"
+  val ScalaJsDom = "2.3.0"
 }

--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/eventProps/FormEventProps.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/eventProps/FormEventProps.scala
@@ -20,7 +20,6 @@ import com.raquo.domtypes.generic.builders.EventPropBuilder
   *            - Similarly for `onChange` and `onSelect` – these could also fire on an `HTMLTextAreaElement`.
   * @tparam DomInputEvent
   *            DOM InputEvent https://developer.mozilla.org/en-US/docs/Web/API/InputEvent
-  *            Note: This type is not implemented in scala-js-dom
   */
 trait FormEventProps[
   EP[_ <: DomEvent],

--- a/shared/src/main/scala/com/raquo/domtypes/generic/defs/eventProps/FormEventProps.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/generic/defs/eventProps/FormEventProps.scala
@@ -49,6 +49,17 @@ trait FormEventProps[
   lazy val onSelect: EP[DomHtmlElementTargetEvent] = eventProp("select")
 
   /**
+    * The DOM beforeinput event fires when the value of an <input>, or <textarea>
+    * element is about to be modified. The event also applies to elements with
+    * contenteditable enabled, and to any element when designMode is turned on.
+    *
+    * MDN
+    *
+    * @note IE does not support this event.
+    */
+  lazy val onBeforeInput: EP[DomInputEvent] = eventProp("beforeinput")
+
+  /**
     * The input event is fired for input, select, textarea, and
     * contentEditable elements when it gets user input.
     */


### PR DESCRIPTION
Finally added this 😅

I'm a bit confused, it wasn't obvious to me if `DomInputEvent` is being used anywhere?
https://github.com/raquo/scala-dom-types/blob/de166bd3816ae2ad35bbc2fb405a120e46a03afb/shared/src/main/scala/com/raquo/domtypes/generic/defs/eventProps/FormEventProps.scala#L24-L33