### PR TITLE
Escape html tags in scaladoc

### DIFF
--- a/js/src/test/scala/com/thirdparty/defs/attrs/HtmlAttrs.scala
+++ b/js/src/test/scala/com/thirdparty/defs/attrs/HtmlAttrs.scala
@@ -82,7 +82,7 @@ trait HtmlAttrs {
 
 
   /**
-    * The max attribute specifies the maximum value for an <input> element of type
+    * The max attribute specifies the maximum value for an `<input>` element of type
     * number, range, date, datetime, datetime-local, month, time, or week.
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/max
@@ -91,7 +91,7 @@ trait HtmlAttrs {
 
 
   /**
-    * The min attribute specifies the minimum value for an <input> element of type
+    * The min attribute specifies the minimum value for an `<input>` element of type
     * number, range, date, datetime, datetime-local, month, time, or week.
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/min
@@ -100,12 +100,12 @@ trait HtmlAttrs {
 
 
   /**
-    * The step attribute specifies the numeric intervals for an <input> element
+    * The step attribute specifies the numeric intervals for an `<input>` element
     * that should be considered legal for the input. For example, if step is 2
-    * on a number typed <input> then the legal numbers could be -2, 0, 2, 4, 6
+    * on a number typed `<input>` then the legal numbers could be -2, 0, 2, 4, 6
     * etc. The step attribute should be used in conjunction with the min and
     * max attributes to specify the full range and interval of the legal values.
-    * The step attribute is applicable to <input> elements of the following
+    * The step attribute is applicable to `<input>` elements of the following
     * types: number, range, date, datetime, datetime-local, month, time and week.
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/step

--- a/js/src/test/scala/com/thirdparty/defs/attrs/SvgAttrs.scala
+++ b/js/src/test/scala/com/thirdparty/defs/attrs/SvgAttrs.scala
@@ -30,7 +30,7 @@ trait SvgAttrs {
     * If the attribute is not specified, the effect is as if the attribute
     * were set to the value of the ascent attribute.
     * 
-    * Value 	<number>
+    * Value 	`<number>`
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/accent-height
     */
@@ -89,7 +89,7 @@ trait SvgAttrs {
     * the effect is as if the attribute were set to the vert-origin-y value
     * for the corresponding font.
     * 
-    * Value 	<number>
+    * Value 	`<number>`
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/ascent
     */
@@ -100,7 +100,7 @@ trait SvgAttrs {
     * This attribute indicates the name of the attribute in the parent element
     * that is going to be changed during an animation.
     * 
-    * Value 	<attributeName>
+    * Value 	`<attributeName>`
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/attributeName
     */
@@ -124,7 +124,7 @@ trait SvgAttrs {
     * If the attribute is not specified, then the effect is as if a
     * value of 0 were specified.
     * 
-    * Value 	<number>
+    * Value 	`<number>`
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/azimuth
     */
@@ -133,7 +133,7 @@ trait SvgAttrs {
 
   /**
     * The baseFrequency attribute represent The base frequencies parameter
-    * for the noise function of the <feturbulence> primitive. If two <number>s
+    * for the noise function of the `<feturbulence>` primitive. If two `<number>`s
     * are provided, the first number represents a base frequency in the X
     * direction and the second value represents a base frequency in the Y direction.
     * If one number is provided, then that value is used for both X and Y.
@@ -141,7 +141,7 @@ trait SvgAttrs {
     * If the attribute is not specified, then the effect is as if a value
     * of 0 were specified.
     * 
-    * Value 	<number-optional-number>
+    * Value 	`<number-optional-number>`
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/baseFrequency
     */
@@ -167,10 +167,10 @@ trait SvgAttrs {
     * The attribute value is a semicolon separated list of values. The interpretation
     * of a list of start times is detailed in the SMIL specification in "Evaluation
     * of begin and end time lists". Each individual value can be one of the following:
-    * <offset-value>, <syncbase-value>, <event-value>, <repeat-value>, <accessKey-value>,
-    * <wallclock-sync-value> or the keyword indefinite.
+    * `<offset-value>`, `<syncbase-value>`, `<event-value>`, `<repeat-value>`, `<accessKey-value>`,
+    * `<wallclock-sync-value>` or the keyword indefinite.
     * 
-    * Value 	<begin-value-list>
+    * Value 	`<begin-value-list>`
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/begin
     */
@@ -179,12 +179,12 @@ trait SvgAttrs {
 
   /**
     * The bias attribute shifts the range of the filter. After applying the kernelMatrix
-    * of the <feConvolveMatrix> element to the input image to yield a number and applied
+    * of the `<feConvolveMatrix>` element to the input image to yield a number and applied
     * the divisor attribute, the bias attribute is added to each component. This allows
     * representation of values that would otherwise be clamped to 0 or 1.
     * If bias is not specified, then the effect is as if a value of 0 were specified.
     * 
-    * Value 	<number>
+    * Value 	`<number>`
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/bias
     */
@@ -206,12 +206,12 @@ trait SvgAttrs {
   /**
     * The clip attribute has the same parameter values as defined for the css clip property.
     * Unitless values, which indicate current user coordinates, are permitted on the coordinate
-    * values on the <shape>. The value of auto defines a clipping path along the bounds of
+    * values on the `<shape>`. The value of auto defines a clipping path along the bounds of
     * the viewport created by the given element.
     * As a presentation attribute, it also can be used as a property directly inside a
     * CSS stylesheet, see css clip for further information.
     * 
-    * Value 	auto | <shape> | inherit
+    * Value 	`auto | <shape> | inherit`
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/clip
     */
@@ -219,10 +219,10 @@ trait SvgAttrs {
 
 
   /**
-    * The clip-path attribute bind the element is applied to with a given <clipPath> element
+    * The clip-path attribute bind the element is applied to with a given `<clipPath>` element
     * As a presentation attribute, it also can be used as a property directly inside a CSS stylesheet
     * 
-    * Value 	<FuncIRI> | none | inherit
+    * Value 	`<FuncIRI> | none | inherit`
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/clip-path
     */
@@ -231,9 +231,9 @@ trait SvgAttrs {
 
   /**
     * The clipPathUnits attribute defines the coordinate system for the contents
-    * of the <clipPath> element. the clipPathUnits attribute is not specified,
+    * of the `<clipPath>` element. the clipPathUnits attribute is not specified,
     * then the effect is as if a value of userSpaceOnUse were specified.
-    * Note that values defined as a percentage inside the content of the <clipPath>
+    * Note that values defined as a percentage inside the content of the `<clipPath>`
     * are not affected by this attribute. It means that even if you set the value of
     * maskContentUnits to objectBoundingBox, percentage values will be calculated as
     * if the value of the attribute were userSpaceOnUse.
@@ -247,8 +247,8 @@ trait SvgAttrs {
 
   /**
     * The clip-rule attribute only applies to graphics elements that are contained within a
-    * <clipPath> element. The clip-rule attribute basically works as the fill-rule attribute,
-    * except that it applies to <clipPath> definitions.
+    * `<clipPath>` element. The clip-rule attribute basically works as the fill-rule attribute,
+    * except that it applies to `<clipPath>` definitions.
     * 
     * Value 	nonezero | evenodd | inherit
     * 
@@ -263,7 +263,7 @@ trait SvgAttrs {
     * As a presentation attribute, it also can be used as a property directly inside a CSS
     * stylesheet, see css color for further information.
     * 
-    * Value 	<color> | inherit
+    * Value 	`<color> | inherit`
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/color
     */
@@ -309,11 +309,11 @@ trait SvgAttrs {
 
   /**
     * The color-profile attribute is used to define which color profile a raster image
-    * included through the <image> element should use. As a presentation attribute, it
+    * included through the `<image>` element should use. As a presentation attribute, it
     * also can be used as a property directly inside a CSS stylesheet, see css color-profile
     * for further information.
     * 
-    * Value 	auto | sRGB | <name> | <IRI> | inherit
+    * Value 	`auto | sRGB | <name> | <IRI> | inherit`
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/color-profile
     */
@@ -339,14 +339,14 @@ trait SvgAttrs {
 
 
   /**
-    * The contentScriptType attribute on the <svg> element specifies the default scripting
+    * The contentScriptType attribute on the `<svg>` element specifies the default scripting
     * language for the given document fragment.
     * This attribute sets the default scripting language used to process the value strings
     * in event attributes. This language must be used for all instances of script that do not
     * specify their own scripting language. The value content-type specifies a media type,
     * per MIME Part Two: Media Types [RFC2046]. The default value is application/ecmascript
     * 
-    * Value 	<content-type>
+    * Value 	`<content-type>`
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/contentScriptType
     */
@@ -355,10 +355,10 @@ trait SvgAttrs {
 
   /**
     * This attribute specifies the style sheet language for the given document fragment.
-    * The contentStyleType is specified on the <svg> element. By default, if it's not defined,
+    * The contentStyleType is specified on the `<svg>` element. By default, if it's not defined,
     * the value is text/css
     * 
-    * Value 	<content-type>
+    * Value 	`<content-type>`
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/contentStyleType
     */
@@ -368,8 +368,8 @@ trait SvgAttrs {
   /**
     * The cursor attribute specifies the mouse cursor displayed when the mouse pointer
     * is over an element.This attribute behave exactly like the css cursor property except
-    * that if the browser suport the <cursor> element, it should allow to use it with the
-    * <funciri> notation. As a presentation attribute, it also can be used as a property
+    * that if the browser suport the `<cursor>` element, it should allow to use it with the
+    * `<funciri>` notation. As a presentation attribute, it also can be used as a property
     * directly inside a CSS stylesheet, see css cursor for further information.
     * 
     * Value 	 auto | crosshair | default | pointer | move | e-resize |
@@ -382,15 +382,15 @@ trait SvgAttrs {
 
 
   /**
-    * For the <circle> and the <ellipse> element, this attribute define the x-axis coordinate
+    * For the `<circle>` and the `<ellipse>` element, this attribute define the x-axis coordinate
     * of the center of the element. If the attribute is not specified, the effect is as if a
-    * value of "0" were specified.For the <radialGradient> element, this attribute define
+    * value of "0" were specified.For the `<radialGradient>` element, this attribute define
     * the x-axis coordinate of the largest (i.e., outermost) circle for the radial gradient.
     * The gradient will be drawn such that the 100% gradient stop is mapped to the perimeter
     * of this largest (i.e., outermost) circle. If the attribute is not specified, the effect
     * is as if a value of 50% were specified
     * 
-    * Value 	<coordinate>
+    * Value 	`<coordinate>`
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/cx
     */
@@ -398,15 +398,15 @@ trait SvgAttrs {
 
 
   /**
-    * For the <circle> and the <ellipse> element, this attribute define the y-axis coordinate
+    * For the `<circle>` and the `<ellipse>` element, this attribute define the y-axis coordinate
     * of the center of the element. If the attribute is not specified, the effect is as if a
-    * value of "0" were specified.For the <radialGradient> element, this attribute define
+    * value of "0" were specified.For the `<radialGradient>` element, this attribute define
     * the x-axis coordinate of the largest (i.e., outermost) circle for the radial gradient.
     * The gradient will be drawn such that the 100% gradient stop is mapped to the perimeter
     * of this largest (i.e., outermost) circle. If the attribute is not specified, the effect
     * is as if a value of 50% were specified
     * 
-    * Value 	<coordinate>
+    * Value 	`<coordinate>`
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/cy
     */
@@ -668,7 +668,7 @@ trait SvgAttrs {
   /**
     * This attribute defines the orientation of the marker relative to the shape it is attached to.
     * 
-    * Value type: auto|auto-start-reverse|<angle> ; Default value: 0; Animatable: yes
+    * Value type: `auto|auto-start-reverse|<angle>` ; Default value: 0; Animatable: yes
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/orient
     */

--- a/js/src/test/scala/com/thirdparty/defs/eventProps/GlobalEventProps.scala
+++ b/js/src/test/scala/com/thirdparty/defs/eventProps/GlobalEventProps.scala
@@ -322,7 +322,7 @@ trait GlobalEventProps {
 
 
   /**
-    * The DOM beforeinput event fires when the value of an <input>, or <textarea>
+    * The DOM beforeinput event fires when the value of an `<input>`, or `<textarea>`
     * element is about to be modified. The event also applies to elements with
     * contenteditable enabled, and to any element when designMode is turned on.
     * 
@@ -364,7 +364,7 @@ trait GlobalEventProps {
 
   /**
     * The submit event is fired when the user clicks a submit button in a form
-    * (<input type="submit"/>).
+    * (`<input type="submit"/>`).
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit_event
     */
@@ -388,7 +388,7 @@ trait GlobalEventProps {
 
 
   /**
-    * Fires when the user writes something in a search field (for <input="search">)
+    * Fires when the user writes something in a search field (for `<input="search">`)
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/search_event
     */
@@ -487,7 +487,7 @@ trait GlobalEventProps {
 
 
   /**
-    * Script to be run when the cue changes in a <track> element
+    * Script to be run when the cue changes in a `<track>` element
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/API/TextTrack/cuechange_event
     */
@@ -690,7 +690,7 @@ trait GlobalEventProps {
 
   /**
     * The onload property of the GlobalEventHandlers mixin is an event handler
-    * for the load event of a Window, XMLHttpRequest, <img> element, etc.,
+    * for the load event of a Window, XMLHttpRequest, `<img>` element, etc.,
     * which fires when the resource has loaded.
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event
@@ -719,7 +719,7 @@ trait GlobalEventProps {
 
 
   /**
-    * Fires when a <menu> element is shown as a context menu
+    * Fires when a `<menu>` element is shown as a context menu
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/show_event
     */
@@ -727,7 +727,7 @@ trait GlobalEventProps {
 
 
   /**
-    * Fires when the user opens or closes the <details> element
+    * Fires when the user opens or closes the `<details>` element
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/toggle_event
     */

--- a/js/src/test/scala/com/thirdparty/defs/props/Props.scala
+++ b/js/src/test/scala/com/thirdparty/defs/props/Props.scala
@@ -50,7 +50,7 @@ trait Props {
 
 
   /**
-    * Indicates whether an <option> element is _currently_ selected.
+    * Indicates whether an `<option>` element is _currently_ selected.
     * This is different from `selected` _attribute_,
     * which contains the _initial_ selected status of the element.
     * More info: https://stackoverflow.com/a/6004028/2601788 (`selected` behaves similar to `value`)
@@ -150,7 +150,7 @@ trait Props {
 
 
   /**
-    * The visible width of text input or <textArea>, in average character widths.
+    * The visible width of text input or `<textArea>`, in average character widths.
     * If it is specified, it must be a positive integer.
     * If it is not specified, the default value is 20 (HTML5).
     * 
@@ -162,7 +162,7 @@ trait Props {
   /**
     * This attribute contains a non-negative integer value that indicates for
     * how many columns the cell extends. Its default value is 1; if its value
-    * is set to 0, it extends until the end of the <colgroup>, even if implicitly
+    * is set to 0, it extends until the end of the `<colgroup>`, even if implicitly
     * defined, that the cell belongs to. Values higher than 1000 will be considered
     * as incorrect and will be set to the default value (1).
     * 
@@ -173,7 +173,7 @@ trait Props {
 
   /**
     * This attribute gives the value associated with the [[name]] or [[httpEquiv]] attribute,
-    * of a <meta> element, depending on which of those attributes is defined on that element.
+    * of a `<meta>` element, depending on which of those attributes is defined on that element.
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-content
     */
@@ -193,8 +193,8 @@ trait Props {
 
 
   /**
-    * Indicates whether this <option> is initially selected
-    * in an option list of a <select> element.
+    * Indicates whether this `<option>` is initially selected
+    * in an option list of a `<select>` element.
     * 
     * See [[Props.selected]]
     * 
@@ -516,8 +516,8 @@ trait Props {
 
   /**
     * This Boolean attribute specifies, when present/true, that the user is allowed
-    * to enter more than one value for the <input> element for types "email" or "file".
-    * It can also be provided to the <select> element to allow selecting more than one
+    * to enter more than one value for the `<input>` element for types "email" or "file".
+    * It can also be provided to the `<select>` element to allow selecting more than one
     * option.
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#multiple
@@ -544,7 +544,7 @@ trait Props {
     * This Boolean attribute indicates that the form is not to be validated when
     * submitted. If this attribute is not specified (and therefore the form is
     * validated), this default setting can be overridden by a formnovalidate
-    * attribute on a <button> or <input> element belonging to the form.
+    * attribute on a `<button>` or `<input>` element belonging to the form.
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-novalidate
     */
@@ -614,7 +614,7 @@ trait Props {
   /**
     * This attribute contains a non-negative integer value that indicates for how many
     * rows the cell extends. Its default value is 1; if its value is set to 0, it extends
-    * until the end of the table section (<thead>, <tbody>, <tfoot>, even if implicitly
+    * until the end of the table section (`<thead>`, `<tbody>`, `<tfoot>`, even if implicitly
     * defined, that the cell belongs to. Values higher than 65534 are clipped down to 65534.
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td#attr-rowspan

--- a/js/src/test/scala/com/thirdparty/defs/styles/StyleProps.scala
+++ b/js/src/test/scala/com/thirdparty/defs/styles/StyleProps.scala
@@ -315,7 +315,7 @@ trait StyleProps {
   /**
     * The CSS animation-timing-function property specifies how a CSS animation
     * should progress over the duration of each cycle. The possible values are
-    * one or several <timing-function>.
+    * one or several `<timing-function>`.
     * 
     * For keyframed animations, the timing function applies between keyframes
     * rather than over the entire animation. In other words, the timing function
@@ -1703,7 +1703,7 @@ trait StyleProps {
 
 
   /**
-    * The table-layout CSS property sets the algorithm used to lay out <table>
+    * The table-layout CSS property sets the algorithm used to lay out `<table>`
     * cells, rows, and columns.
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/CSS/table-layout
@@ -1950,7 +1950,7 @@ trait StyleProps {
 
   /**
     * The visibility CSS property shows or hides an element without changing the
-    * layout of a document. The property can also hide rows or columns in a <table>.
+    * layout of a document. The property can also hide rows or columns in a `<table>`.
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/CSS/visibility
     */

--- a/js/src/test/scala/com/thirdparty/defs/styles/traits/Display.scala
+++ b/js/src/test/scala/com/thirdparty/defs/styles/traits/Display.scala
@@ -56,7 +56,7 @@ trait Display extends None { this: StyleProp[_] =>
 
   /**
     * The element behaves like an inline element and lays out its content according
-    * to the ruby formatting model. It behaves like the corresponding HTML <ruby>
+    * to the ruby formatting model. It behaves like the corresponding HTML `<ruby>`
     * elements.
     */
   lazy val ruby: StyleSetter[_] = this := "ruby"

--- a/js/src/test/scala/com/thirdparty/defs/tags/HtmlTags.scala
+++ b/js/src/test/scala/com/thirdparty/defs/tags/HtmlTags.scala
@@ -1027,7 +1027,7 @@ trait HtmlTags {
     * Dialog box or other interactive component, such as a dismissible alert,
     * inspector, or subwindow.
     * 
-    * Note: The tabindex attribute must not be used on the <dialog> element
+    * Note: The tabindex attribute must not be used on the `<dialog>` element
     * 
     * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog
     * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement

--- a/shared/src/main/scala/com/raquo/domtypes/defs/attrs/HtmlAttrDefs.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/defs/attrs/HtmlAttrDefs.scala
@@ -123,7 +123,7 @@ object HtmlAttrDefs {
       scalaValueType = "String",
       codec = "StringAsIs",
       commentLines = List(
-        "The max attribute specifies the maximum value for an <input> element of type",
+        "The max attribute specifies the maximum value for an `<input>` element of type",
         "number, range, date, datetime, datetime-local, month, time, or week.",
       ),
       docUrls = List(
@@ -139,7 +139,7 @@ object HtmlAttrDefs {
       scalaValueType = "String",
       codec = "StringAsIs",
       commentLines = List(
-        "The min attribute specifies the minimum value for an <input> element of type",
+        "The min attribute specifies the minimum value for an `<input>` element of type",
         "number, range, date, datetime, datetime-local, month, time, or week.",
       ),
       docUrls = List(
@@ -155,12 +155,12 @@ object HtmlAttrDefs {
       scalaValueType = "String",
       codec = "StringAsIs",
       commentLines = List(
-        "The step attribute specifies the numeric intervals for an <input> element",
+        "The step attribute specifies the numeric intervals for an `<input>` element",
         "that should be considered legal for the input. For example, if step is 2",
-        "on a number typed <input> then the legal numbers could be -2, 0, 2, 4, 6",
+        "on a number typed `<input>` then the legal numbers could be -2, 0, 2, 4, 6",
         "etc. The step attribute should be used in conjunction with the min and",
         "max attributes to specify the full range and interval of the legal values.",
-        "The step attribute is applicable to <input> elements of the following",
+        "The step attribute is applicable to `<input>` elements of the following",
         "types: number, range, date, datetime, datetime-local, month, time and week.",
       ),
       docUrls = List(

--- a/shared/src/main/scala/com/raquo/domtypes/defs/attrs/SvgAttrDefs.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/defs/attrs/SvgAttrDefs.scala
@@ -19,7 +19,7 @@ object SvgAttrDefs {
         "If the attribute is not specified, the effect is as if the attribute",
         "were set to the value of the ascent attribute.",
         "",
-        "Value 	<number>",
+        "Value 	`<number>`",
       ),
       docUrls = List(
         "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/accent-height",
@@ -106,7 +106,7 @@ object SvgAttrDefs {
         "the effect is as if the attribute were set to the vert-origin-y value",
         "for the corresponding font.",
         "",
-        "Value 	<number>",
+        "Value 	`<number>`",
       ),
       docUrls = List(
         "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/ascent",
@@ -124,7 +124,7 @@ object SvgAttrDefs {
         "This attribute indicates the name of the attribute in the parent element",
         "that is going to be changed during an animation.",
         "",
-        "Value 	<attributeName>",
+        "Value 	`<attributeName>`",
       ),
       docUrls = List(
         "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/attributeName",
@@ -162,7 +162,7 @@ object SvgAttrDefs {
         "If the attribute is not specified, then the effect is as if a",
         "value of 0 were specified.",
         "",
-        "Value 	<number>",
+        "Value 	`<number>`",
       ),
       docUrls = List(
         "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/azimuth",
@@ -178,7 +178,7 @@ object SvgAttrDefs {
       codec = "StringAsIs",
       commentLines = List(
         "The baseFrequency attribute represent The base frequencies parameter",
-        "for the noise function of the <feturbulence> primitive. If two <number>s",
+        "for the noise function of the `<feturbulence>` primitive. If two `<number>`s",
         "are provided, the first number represents a base frequency in the X",
         "direction and the second value represents a base frequency in the Y direction.",
         "If one number is provided, then that value is used for both X and Y.",
@@ -186,7 +186,7 @@ object SvgAttrDefs {
         "If the attribute is not specified, then the effect is as if a value",
         "of 0 were specified.",
         "",
-        "Value 	<number-optional-number>",
+        "Value 	`<number-optional-number>`",
       ),
       docUrls = List(
         "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/baseFrequency",
@@ -226,10 +226,10 @@ object SvgAttrDefs {
         "The attribute value is a semicolon separated list of values. The interpretation",
         "of a list of start times is detailed in the SMIL specification in \"Evaluation",
         "of begin and end time lists\". Each individual value can be one of the following:",
-        "<offset-value>, <syncbase-value>, <event-value>, <repeat-value>, <accessKey-value>,",
-        "<wallclock-sync-value> or the keyword indefinite.",
+        "`<offset-value>`, `<syncbase-value>`, `<event-value>`, `<repeat-value>`, `<accessKey-value>`,",
+        "`<wallclock-sync-value>` or the keyword indefinite.",
         "",
-        "Value 	<begin-value-list>",
+        "Value 	`<begin-value-list>`",
       ),
       docUrls = List(
         "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/begin",
@@ -245,12 +245,12 @@ object SvgAttrDefs {
       codec = "DoubleAsString",
       commentLines = List(
         "The bias attribute shifts the range of the filter. After applying the kernelMatrix",
-        "of the <feConvolveMatrix> element to the input image to yield a number and applied",
+        "of the `<feConvolveMatrix>` element to the input image to yield a number and applied",
         "the divisor attribute, the bias attribute is added to each component. This allows",
         "representation of values that would otherwise be clamped to 0 or 1.",
         "If bias is not specified, then the effect is as if a value of 0 were specified.",
         "",
-        "Value 	<number>",
+        "Value 	`<number>`",
       ),
       docUrls = List(
         "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/bias",
@@ -286,12 +286,12 @@ object SvgAttrDefs {
       commentLines = List(
         "The clip attribute has the same parameter values as defined for the css clip property.",
         "Unitless values, which indicate current user coordinates, are permitted on the coordinate",
-        "values on the <shape>. The value of auto defines a clipping path along the bounds of",
+        "values on the `<shape>`. The value of auto defines a clipping path along the bounds of",
         "the viewport created by the given element.",
         "As a presentation attribute, it also can be used as a property directly inside a",
         "CSS stylesheet, see css clip for further information.",
         "",
-        "Value 	auto | <shape> | inherit",
+        "Value 	`auto | <shape> | inherit`",
       ),
       docUrls = List(
         "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/clip",
@@ -306,10 +306,10 @@ object SvgAttrDefs {
       scalaValueType = "String",
       codec = "StringAsIs",
       commentLines = List(
-        "The clip-path attribute bind the element is applied to with a given <clipPath> element",
+        "The clip-path attribute bind the element is applied to with a given `<clipPath>` element",
         "As a presentation attribute, it also can be used as a property directly inside a CSS stylesheet",
         "",
-        "Value 	<FuncIRI> | none | inherit",
+        "Value 	`<FuncIRI> | none | inherit`",
       ),
       docUrls = List(
         "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/clip-path",
@@ -325,9 +325,9 @@ object SvgAttrDefs {
       codec = "StringAsIs",
       commentLines = List(
         "The clipPathUnits attribute defines the coordinate system for the contents",
-        "of the <clipPath> element. the clipPathUnits attribute is not specified,",
+        "of the `<clipPath>` element. the clipPathUnits attribute is not specified,",
         "then the effect is as if a value of userSpaceOnUse were specified.",
-        "Note that values defined as a percentage inside the content of the <clipPath>",
+        "Note that values defined as a percentage inside the content of the `<clipPath>`",
         "are not affected by this attribute. It means that even if you set the value of",
         "maskContentUnits to objectBoundingBox, percentage values will be calculated as",
         "if the value of the attribute were userSpaceOnUse.",
@@ -348,8 +348,8 @@ object SvgAttrDefs {
       codec = "StringAsIs",
       commentLines = List(
         "The clip-rule attribute only applies to graphics elements that are contained within a",
-        "<clipPath> element. The clip-rule attribute basically works as the fill-rule attribute,",
-        "except that it applies to <clipPath> definitions.",
+        "`<clipPath>` element. The clip-rule attribute basically works as the fill-rule attribute,",
+        "except that it applies to `<clipPath>` definitions.",
         "",
         "Value 	nonezero | evenodd | inherit",
       ),
@@ -371,7 +371,7 @@ object SvgAttrDefs {
         "As a presentation attribute, it also can be used as a property directly inside a CSS",
         "stylesheet, see css color for further information.",
         "",
-        "Value 	<color> | inherit",
+        "Value 	`<color> | inherit`",
       ),
       docUrls = List(
         "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/color",
@@ -438,11 +438,11 @@ object SvgAttrDefs {
       codec = "StringAsIs",
       commentLines = List(
         "The color-profile attribute is used to define which color profile a raster image",
-        "included through the <image> element should use. As a presentation attribute, it",
+        "included through the `<image>` element should use. As a presentation attribute, it",
         "also can be used as a property directly inside a CSS stylesheet, see css color-profile",
         "for further information.",
         "",
-        "Value 	auto | sRGB | <name> | <IRI> | inherit",
+        "Value 	`auto | sRGB | <name> | <IRI> | inherit`",
       ),
       docUrls = List(
         "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/color-profile",
@@ -482,14 +482,14 @@ object SvgAttrDefs {
       scalaValueType = "String",
       codec = "StringAsIs",
       commentLines = List(
-        "The contentScriptType attribute on the <svg> element specifies the default scripting",
+        "The contentScriptType attribute on the `<svg>` element specifies the default scripting",
         "language for the given document fragment.",
         "This attribute sets the default scripting language used to process the value strings",
         "in event attributes. This language must be used for all instances of script that do not",
         "specify their own scripting language. The value content-type specifies a media type,",
         "per MIME Part Two: Media Types [RFC2046]. The default value is application/ecmascript",
         "",
-        "Value 	<content-type>",
+        "Value 	`<content-type>`",
       ),
       docUrls = List(
         "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/contentScriptType",
@@ -505,10 +505,10 @@ object SvgAttrDefs {
       codec = "StringAsIs",
       commentLines = List(
         "This attribute specifies the style sheet language for the given document fragment.",
-        "The contentStyleType is specified on the <svg> element. By default, if it's not defined,",
+        "The contentStyleType is specified on the `<svg>` element. By default, if it's not defined,",
         "the value is text/css",
         "",
-        "Value 	<content-type>",
+        "Value 	`<content-type>`",
       ),
       docUrls = List(
         "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/contentStyleType",
@@ -525,8 +525,8 @@ object SvgAttrDefs {
       commentLines = List(
         "The cursor attribute specifies the mouse cursor displayed when the mouse pointer",
         "is over an element.This attribute behave exactly like the css cursor property except",
-        "that if the browser suport the <cursor> element, it should allow to use it with the",
-        "<funciri> notation. As a presentation attribute, it also can be used as a property",
+        "that if the browser suport the `<cursor>` element, it should allow to use it with the",
+        "`<funciri>` notation. As a presentation attribute, it also can be used as a property",
         "directly inside a CSS stylesheet, see css cursor for further information.",
         "",
         "Value 	 auto | crosshair | default | pointer | move | e-resize |",
@@ -546,15 +546,15 @@ object SvgAttrDefs {
       scalaValueType = "String",
       codec = "StringAsIs",
       commentLines = List(
-        "For the <circle> and the <ellipse> element, this attribute define the x-axis coordinate",
+        "For the `<circle>` and the `<ellipse>` element, this attribute define the x-axis coordinate",
         "of the center of the element. If the attribute is not specified, the effect is as if a",
-        "value of \"0\" were specified.For the <radialGradient> element, this attribute define",
+        "value of \"0\" were specified.For the `<radialGradient>` element, this attribute define",
         "the x-axis coordinate of the largest (i.e., outermost) circle for the radial gradient.",
         "The gradient will be drawn such that the 100% gradient stop is mapped to the perimeter",
         "of this largest (i.e., outermost) circle. If the attribute is not specified, the effect",
         "is as if a value of 50% were specified",
         "",
-        "Value 	<coordinate>",
+        "Value 	`<coordinate>`",
       ),
       docUrls = List(
         "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/cx",
@@ -569,15 +569,15 @@ object SvgAttrDefs {
       scalaValueType = "String",
       codec = "StringAsIs",
       commentLines = List(
-        "For the <circle> and the <ellipse> element, this attribute define the y-axis coordinate",
+        "For the `<circle>` and the `<ellipse>` element, this attribute define the y-axis coordinate",
         "of the center of the element. If the attribute is not specified, the effect is as if a",
-        "value of \"0\" were specified.For the <radialGradient> element, this attribute define",
+        "value of \"0\" were specified.For the `<radialGradient>` element, this attribute define",
         "the x-axis coordinate of the largest (i.e., outermost) circle for the radial gradient.",
         "The gradient will be drawn such that the 100% gradient stop is mapped to the perimeter",
         "of this largest (i.e., outermost) circle. If the attribute is not specified, the effect",
         "is as if a value of 50% were specified",
         "",
-        "Value 	<coordinate>",
+        "Value 	`<coordinate>`",
       ),
       docUrls = List(
         "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/cy",
@@ -1413,7 +1413,7 @@ object SvgAttrDefs {
       commentLines = List(
         "This attribute defines the orientation of the marker relative to the shape it is attached to.",
         "",
-        "Value type: auto|auto-start-reverse|<angle> ; Default value: 0; Animatable: yes",
+        "Value type: `auto|auto-start-reverse|<angle>` ; Default value: 0; Animatable: yes",
       ),
       docUrls = List(
         "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/orient",

--- a/shared/src/main/scala/com/raquo/domtypes/defs/eventProps/FormEventPropDefs.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/defs/eventProps/FormEventPropDefs.scala
@@ -41,7 +41,7 @@ object FormEventPropDefs {
       scalaJsEventType = "dom.InputEvent",
       javascriptEventType = "InputEvent",
       commentLines = List(
-        "The DOM beforeinput event fires when the value of an <input>, or <textarea>",
+        "The DOM beforeinput event fires when the value of an `<input>`, or `<textarea>`",
         "element is about to be modified. The event also applies to elements with",
         "contenteditable enabled, and to any element when designMode is turned on.",
         "",
@@ -103,7 +103,7 @@ object FormEventPropDefs {
       javascriptEventType = "Event",
       commentLines = List(
         "The submit event is fired when the user clicks a submit button in a form",
-        "(<input type=\"submit\"/>).",
+        "(`<input type=\"submit\"/>`).",
       ),
       docUrls = List(
         "https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit_event",
@@ -142,7 +142,7 @@ object FormEventPropDefs {
       scalaJsEventType = "dom.Event",
       javascriptEventType = "Event",
       commentLines = List(
-        "Fires when the user writes something in a search field (for <input=\"search\">)",
+        "Fires when the user writes something in a search field (for `<input=\"search\">`)",
       ),
       docUrls = List(
         "https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/search_event",

--- a/shared/src/main/scala/com/raquo/domtypes/defs/eventProps/MediaEventPropDefs.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/defs/eventProps/MediaEventPropDefs.scala
@@ -56,7 +56,7 @@ object MediaEventPropDefs {
       scalaJsEventType = "dom.Event",
       javascriptEventType = "Event",
       commentLines = List(
-        "Script to be run when the cue changes in a <track> element",
+        "Script to be run when the cue changes in a `<track>` element",
       ),
       docUrls = List(
         "https://developer.mozilla.org/en-US/docs/Web/API/TextTrack/cuechange_event",

--- a/shared/src/main/scala/com/raquo/domtypes/defs/eventProps/MiscellaneousEventPropDefs.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/defs/eventProps/MiscellaneousEventPropDefs.scala
@@ -14,7 +14,7 @@ object MiscellaneousEventPropDefs {
       javascriptEventType = "UIEvent",
       commentLines = List(
         "The onload property of the GlobalEventHandlers mixin is an event handler",
-        "for the load event of a Window, XMLHttpRequest, <img> element, etc.,",
+        "for the load event of a Window, XMLHttpRequest, `<img>` element, etc.,",
         "which fires when the resource has loaded.",
       ),
       docUrls = List(
@@ -58,7 +58,7 @@ object MiscellaneousEventPropDefs {
       scalaJsEventType = "dom.Event",
       javascriptEventType = "Event",
       commentLines = List(
-        "Fires when a <menu> element is shown as a context menu",
+        "Fires when a `<menu>` element is shown as a context menu",
       ),
       docUrls = List(
         "https://developer.mozilla.org/en-US/docs/Web/API/Element/show_event",
@@ -71,7 +71,7 @@ object MiscellaneousEventPropDefs {
       scalaJsEventType = "dom.Event",
       javascriptEventType = "Event",
       commentLines = List(
-        "Fires when the user opens or closes the <details> element",
+        "Fires when the user opens or closes the `<details>` element",
       ),
       docUrls = List(
         "https://developer.mozilla.org/en-US/docs/Web/API/Element/toggle_event",

--- a/shared/src/main/scala/com/raquo/domtypes/defs/props/PropDefs.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/defs/props/PropDefs.scala
@@ -49,7 +49,7 @@ object PropDefs {
       domValueType = "Boolean",
       codec = "BooleanAsIs",
       commentLines = List(
-        "Indicates whether an <option> element is _currently_ selected.",
+        "Indicates whether an `<option>` element is _currently_ selected.",
         "This is different from `selected` _attribute_,",
         "which contains the _initial_ selected status of the element.",
         "More info: https://stackoverflow.com/a/6004028/2601788 (`selected` behaves similar to `value`)",

--- a/shared/src/main/scala/com/raquo/domtypes/defs/reflectedAttrs/ReflectedHtmlAttrDefs.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/defs/reflectedAttrs/ReflectedHtmlAttrDefs.scala
@@ -164,7 +164,7 @@ object ReflectedHtmlAttrDefs {
       attrCodec = "IntAsString",
       propCodec = "IntAsIs",
       commentLines = List(
-        "The visible width of text input or <textArea>, in average character widths.",
+        "The visible width of text input or `<textArea>`, in average character widths.",
         "If it is specified, it must be a positive integer.",
         "If it is not specified, the default value is 20 (HTML5).",
       ),
@@ -184,7 +184,7 @@ object ReflectedHtmlAttrDefs {
       commentLines = List(
         "This attribute contains a non-negative integer value that indicates for",
         "how many columns the cell extends. Its default value is 1; if its value",
-        "is set to 0, it extends until the end of the <colgroup>, even if implicitly",
+        "is set to 0, it extends until the end of the `<colgroup>`, even if implicitly",
         "defined, that the cell belongs to. Values higher than 1000 will be considered",
         "as incorrect and will be set to the default value (1).",
       ),
@@ -203,7 +203,7 @@ object ReflectedHtmlAttrDefs {
       propCodec = "StringAsIs",
       commentLines = List(
         "This attribute gives the value associated with the [[name]] or [[httpEquiv]] attribute,",
-        "of a <meta> element, depending on which of those attributes is defined on that element.",
+        "of a `<meta>` element, depending on which of those attributes is defined on that element.",
       ),
       docUrls = List(
         "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-content",
@@ -239,8 +239,8 @@ object ReflectedHtmlAttrDefs {
       attrCodec = "BooleanAsAttrPresence",
       propCodec = "BooleanAsIs",
       commentLines = List(
-        "Indicates whether this <option> is initially selected",
-        "in an option list of a <select> element.",
+        "Indicates whether this `<option>` is initially selected",
+        "in an option list of a `<select>` element.",
         "",
         "See [[Props.selected]]",
       ),
@@ -778,8 +778,8 @@ object ReflectedHtmlAttrDefs {
       propCodec = "BooleanAsIs",
       commentLines = List(
         "This Boolean attribute specifies, when present/true, that the user is allowed",
-        "to enter more than one value for the <input> element for types \"email\" or \"file\".",
-        "It can also be provided to the <select> element to allow selecting more than one",
+        "to enter more than one value for the `<input>` element for types \"email\" or \"file\".",
+        "It can also be provided to the `<select>` element to allow selecting more than one",
         "option.",
       ),
       docUrls = List(
@@ -822,7 +822,7 @@ object ReflectedHtmlAttrDefs {
         "This Boolean attribute indicates that the form is not to be validated when",
         "submitted. If this attribute is not specified (and therefore the form is",
         "validated), this default setting can be overridden by a formnovalidate",
-        "attribute on a <button> or <input> element belonging to the form.",
+        "attribute on a `<button>` or `<input>` element belonging to the form.",
       ),
       docUrls = List(
         "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-novalidate",
@@ -948,7 +948,7 @@ object ReflectedHtmlAttrDefs {
       commentLines = List(
         "This attribute contains a non-negative integer value that indicates for how many",
         "rows the cell extends. Its default value is 1; if its value is set to 0, it extends",
-        "until the end of the table section (<thead>, <tbody>, <tfoot>, even if implicitly",
+        "until the end of the table section (`<thead>`, `<tbody>`, `<tfoot>`, even if implicitly",
         "defined, that the cell belongs to. Values higher than 65534 are clipped down to 65534.",
       ),
       docUrls = List(

--- a/shared/src/main/scala/com/raquo/domtypes/defs/styles/StylePropDefs.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/defs/styles/StylePropDefs.scala
@@ -195,7 +195,7 @@ object StylePropDefs {
       commentLines = List(
         "The CSS animation-timing-function property specifies how a CSS animation",
         "should progress over the duration of each cycle. The possible values are",
-        "one or several <timing-function>.",
+        "one or several `<timing-function>`.",
         "",
         "For keyframed animations, the timing function applies between keyframes",
         "rather than over the entire animation. In other words, the timing function",
@@ -2463,7 +2463,7 @@ object StylePropDefs {
       valueUnits = Nil,
       implName = implNames.tableLayoutStyle,
       commentLines = List(
-        "The table-layout CSS property sets the algorithm used to lay out <table>",
+        "The table-layout CSS property sets the algorithm used to lay out `<table>`",
         "cells, rows, and columns.",
       ),
       docUrls = List(
@@ -2850,7 +2850,7 @@ object StylePropDefs {
       implName = implNames.visibilityStyle,
       commentLines = List(
         "The visibility CSS property shows or hides an element without changing the",
-        "layout of a document. The property can also hide rows or columns in a <table>.",
+        "layout of a document. The property can also hide rows or columns in a `<table>`.",
       ),
       docUrls = List(
         "https://developer.mozilla.org/en-US/docs/Web/CSS/visibility",

--- a/shared/src/main/scala/com/raquo/domtypes/defs/styles/StyleTraitDefs.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/defs/styles/StyleTraitDefs.scala
@@ -846,7 +846,7 @@ object StyleTraitDefs {
               domName = "ruby",
                   commentLines = List(
                 "The element behaves like an inline element and lays out its content according",
-                "to the ruby formatting model. It behaves like the corresponding HTML <ruby>",
+                "to the ruby formatting model. It behaves like the corresponding HTML `<ruby>`",
                 "elements.",
               ),
               docUrls = Nil,

--- a/shared/src/main/scala/com/raquo/domtypes/defs/tags/MiscTagDefs.scala
+++ b/shared/src/main/scala/com/raquo/domtypes/defs/tags/MiscTagDefs.scala
@@ -513,7 +513,7 @@ object MiscTagDefs {
         "Dialog box or other interactive component, such as a dismissible alert,",
         "inspector, or subwindow.",
         "",
-        "Note: The tabindex attribute must not be used on the <dialog> element"
+        "Note: The tabindex attribute must not be used on the `<dialog>` element"
       ),
       docUrls = List(
         "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog",


### PR DESCRIPTION
They are breaking Scaladoc 3, at least.

For example. scroll to the bottom of this page to see the scaldoc for `cols` (that's where it ends, because that's where it breaks 😅 )
https://s01.oss.sonatype.org/service/local/repositories/snapshots/archive/com/armanbilge/calico-docs_sjs1_3/0.2-100451d-SNAPSHOT/calico-docs_sjs1_3-0.2-100451d-SNAPSHOT-javadoc.jar/!/calico/html/Html.html